### PR TITLE
Shut down the home screen cleanly on SIGINT and SIGTERM

### DIFF
--- a/src/homeapplication.cpp
+++ b/src/homeapplication.cpp
@@ -46,6 +46,11 @@
 #define HOME_DEBUG(things)
 #endif
 
+void HomeApplication::quitSignalHandler(int)
+{
+    qApp->quit();
+}
+
 HomeApplication::HomeApplication(int &argc, char **argv, const QString &qmlPath)
     : QApplication(argc, argv)
     , xEventListeners()
@@ -55,6 +60,8 @@ HomeApplication::HomeApplication(int &argc, char **argv, const QString &qmlPath)
     , xDamageErrorBase(0)
     , _mainWindowInstance(0)
     , _qmlPath(qmlPath)
+    , originalSigIntHandler(signal(SIGINT, quitSignalHandler))
+    , originalSigTermHandler(signal(SIGTERM, quitSignalHandler))
 {
     setApplicationName("Lipstick");
     // TODO: autogenerate this from tags
@@ -80,6 +87,9 @@ HomeApplication::HomeApplication(int &argc, char **argv, const QString &qmlPath)
 HomeApplication::~HomeApplication()
 {
     delete _mainWindowInstance;
+
+    signal(SIGINT, originalSigIntHandler);
+    signal(SIGTERM, originalSigTermHandler);
 }
 
 HomeApplication *HomeApplication::instance()

--- a/src/homeapplication.h
+++ b/src/homeapplication.h
@@ -13,6 +13,7 @@
 #ifndef HOMEAPPLICATION_H_
 #define HOMEAPPLICATION_H_
 
+#include <signal.h>
 #include <QApplication>
 #include <QDeclarativeView>
 #include "lipstickglobal.h"
@@ -102,6 +103,15 @@ private slots:
      */
     void sendStartupNotifications();
 
+private:
+    //! A signal handler that quits the QApplication
+    static void quitSignalHandler(int);
+
+    //! The original SIGINT handler
+    sighandler_t originalSigIntHandler;
+
+    //! The original SIGTERM handler
+    sighandler_t originalSigTermHandler;
 };
 
 #endif /* HOMEAPPLICATION_H_ */


### PR DESCRIPTION
In order to clean up properly when terminated via SIGINT or SIGTERM the signals need to be caught and the QApplication exited so that all destructors get run.

This is needed by an upcoming patch which stores the notifications on disk. Any notifications not stored on disk need to be written to disk on shutdown. Also, when the sqlite database is used in WAL mode it needs to be properly shut down in order to get all write-ahead-locked data written on disk.
