### PR TITLE
Link the notification tool against the liblipstick version being built

### DIFF
--- a/tools/notificationtool/notificationtool.pro
+++ b/tools/notificationtool/notificationtool.pro
@@ -10,7 +10,8 @@ target.path = /usr/bin
 
 DEPENDPATH += "../../src"
 INCLUDEPATH += "../../src" "../../src/notifications"
-LIBS = -L"../../src" -llipstick
+QMAKE_LIBDIR = ../../src
+LIBS = -llipstick
 
 HEADERS += \
      notificationmanagerproxy.h


### PR DESCRIPTION
qmake puts -L/usr/lib in LIBS, so the notification tool got built against the already installed version of liblipstick instead of the one being built. QMAKE_LIBDIR can be used to add the local directory before /usr/lib in the library search path.
