### PR TITLE
Support for remote actions

### DIFF
--- a/src/notifications/notificationmanager.cpp
+++ b/src/notifications/notificationmanager.cpp
@@ -20,6 +20,7 @@
 #include <QSqlQuery>
 #include <QSqlRecord>
 #include <QSqlTableModel>
+#include <mremoteaction.h>
 #include <sys/statfs.h>
 #include "categorydefinitionstore.h"
 #include "notificationmanageradaptor.h"
@@ -59,6 +60,7 @@ const char *NotificationManager::HINT_TIMESTAMP = "x-nemo-timestamp";
 const char *NotificationManager::HINT_PREVIEW_ICON = "x-nemo-preview-icon";
 const char *NotificationManager::HINT_PREVIEW_BODY = "x-nemo-preview-body";
 const char *NotificationManager::HINT_PREVIEW_SUMMARY = "x-nemo-preview-summary";
+const char *NotificationManager::HINT_REMOTE_ACTION_PREFIX = "x-nemo-remote-action-";
 const char *NotificationManager::HINT_USER_REMOVABLE = "x-nemo-user-removable";
 const char *NotificationManager::HINT_GENERIC_TEXT_TRANSLATION_ID = "x-nemo-generic-text-translation-id";
 const char *NotificationManager::HINT_GENERIC_TEXT_TRANSLATION_CATALOGUE = "x-nemo-generic-text-translation-catalogue";
@@ -114,7 +116,7 @@ QList<uint> NotificationManager::notificationIds() const
 
 QStringList NotificationManager::GetCapabilities()
 {
-    return QStringList() << "body";
+    return QStringList() << "body" << HINT_CLASS << HINT_ICON << HINT_ITEM_COUNT << HINT_TIMESTAMP << HINT_PREVIEW_ICON << HINT_PREVIEW_BODY << HINT_PREVIEW_SUMMARY << "x-nemo-remote-action" << HINT_USER_REMOVABLE << HINT_GENERIC_TEXT_TRANSLATION_ID << HINT_GENERIC_TEXT_TRANSLATION_CATALOGUE;
 }
 
 uint NotificationManager::Notify(const QString &appName, uint replacesId, const QString &appIcon, const QString &summary, const QString &body, const QStringList &actions, const QVariantHash &originalHints, int expireTimeout)
@@ -465,11 +467,23 @@ void NotificationManager::execSQL(const QString &command, const QVariantList &ar
 void NotificationManager::invokeAction(const QString &action)
 {
     Notification *notification = qobject_cast<Notification *>(sender());
-    if (notification != 0 && notification->actions().contains(action)) {
+    if (notification != 0) {
         uint id = notifications.key(notification, 0);
         if (id > 0) {
-            NOTIFICATIONS_DEBUG("INVOKE: " << action << id);
-            emit ActionInvoked(id, action);
+            QString remoteAction = notification->hints().value(QString(HINT_REMOTE_ACTION_PREFIX) + action).toString();
+            if (!remoteAction.isEmpty()) {
+                // If a remote action has been defined for the given action, trigger it
+                MRemoteAction(remoteAction).trigger();
+            }
+
+            for (int actionIndex = 0; actionIndex < notification->actions().count() / 2; actionIndex++) {
+                // Actions are sent over as a list of pairs. Each even element in the list (starting at index 0) represents the identifier for the action. Each odd element in the list is the localized string that will be displayed to the user.
+                if (notification->actions().at(actionIndex * 2) == action) {
+                    NOTIFICATIONS_DEBUG("INVOKE:" << action << id);
+
+                    emit ActionInvoked(id, action);
+                }
+            }
 
             QVariant userRemovable = notification->hints().value(HINT_USER_REMOVABLE);
             if (!userRemovable.isValid() || userRemovable.toBool()) {

--- a/src/notifications/notificationmanager.h
+++ b/src/notifications/notificationmanager.h
@@ -77,6 +77,9 @@ public:
     //! Nemo hint: Summary text of the preview of the notification.
     static const char *HINT_PREVIEW_SUMMARY;
 
+    //! Nemo hint: Remote action of the notification. Prefix only: the action identifier is to be appended.
+    static const char *HINT_REMOTE_ACTION_PREFIX;
+
     //! Nemo hint: User removability of the notification.
     static const char *HINT_USER_REMOVABLE;
 

--- a/tests/ut_notificationmanager/ut_notificationmanager.cpp
+++ b/tests/ut_notificationmanager/ut_notificationmanager.cpp
@@ -22,6 +22,7 @@
 #include <QSqlTableModel>
 #include <QSqlRecord>
 #include <QSqlError>
+#include <mremoteaction.h>
 #include <sys/statfs.h>
 
 const static uint DISK_SPACE_NEEDED = 1024;
@@ -250,6 +251,13 @@ void QTimer::setInterval(int msec)
     timerInterval = interval();
 }
 
+// MRemoteAction stubs
+QStringList mRemoteActionTrigger;
+void MRemoteAction::trigger()
+{
+    mRemoteActionTrigger.append(toString());
+}
+
 void Ut_NotificationManager::init()
 {
     qSqlQueryExecQuery.clear();
@@ -267,6 +275,7 @@ void Ut_NotificationManager::init()
     qSqlDatabaseCommitCalled = false;
     diskSpaceAvailableKb = DISK_SPACE_NEEDED + 100;
     diskSpaceChecked = true;
+    mRemoteActionTrigger.clear();
 }
 
 void Ut_NotificationManager::cleanup()
@@ -369,24 +378,24 @@ void Ut_NotificationManager::testNotificationsAreRestoredOnConstruction()
     notificationValues << notification1Values << notification2Values;
     qSqlQueryValues["SELECT * FROM notifications"].append(notificationValues);
 
-    QHash<int, QVariant> notification1Action1;
-    QHash<int, QVariant> notification1Action2;
-    QHash<int, QVariant> notification2Action1;
-    QHash<int, QVariant> notification2Action2;
-    notification1Action1.insert(0, 1);
-    notification1Action1.insert(1, "action1-1");
-    notification1Action2.insert(0, 1);
-    notification1Action2.insert(1, "action1-2");
-    notification2Action1.insert(0, 2);
-    notification2Action1.insert(1, "action2-1");
-    notification2Action2.insert(0, 2);
-    notification2Action2.insert(1, "action2-2");
+    QHash<int, QVariant> notification1ActionIdentifier;
+    QHash<int, QVariant> notification1ActionName;
+    QHash<int, QVariant> notification2ActionIdentifier;
+    QHash<int, QVariant> notification2ActionName;
+    notification1ActionIdentifier.insert(0, 1);
+    notification1ActionIdentifier.insert(1, "action1");
+    notification1ActionName.insert(0, 1);
+    notification1ActionName.insert(1, "Action 1");
+    notification2ActionIdentifier.insert(0, 2);
+    notification2ActionIdentifier.insert(1, "action2");
+    notification2ActionName.insert(0, 2);
+    notification2ActionName.insert(1, "Action 2");
     QList<QHash<int, QVariant> > notificationActions;
-    notificationActions << notification1Action1 << notification1Action2 << notification2Action1 << notification2Action2;
+    notificationActions << notification1ActionIdentifier << notification1ActionName << notification2ActionIdentifier << notification2ActionName;
     qSqlQueryValues["SELECT * FROM actions"].append(notificationActions);
     QHash<uint, QStringList> notificationActionsById;
-    notificationActionsById.insert(1, QStringList() << "action1-1" << "action1-2");
-    notificationActionsById.insert(2, QStringList() << "action2-1" << "action2-2");
+    notificationActionsById.insert(1, QStringList() << "action1" << "Action 1");
+    notificationActionsById.insert(2, QStringList() << "action2" << "Action 2");
 
     QHash<int, QVariant> notification1Hint1;
     QHash<int, QVariant> notification1Hint2;
@@ -443,10 +452,21 @@ void Ut_NotificationManager::testDatabaseCommitIsDoneOnDestruction()
 
 void Ut_NotificationManager::testCapabilities()
 {
-    // Check that "body" is the only supported capability
+    // Check the supported capabilities includes all the Nemo hints
     QStringList capabilities = NotificationManager::instance()->GetCapabilities();
-    QCOMPARE(capabilities.count(), 1);
+    QCOMPARE(capabilities.count(), 12);
     QCOMPARE(capabilities.contains("body"), QBool(true));
+    QCOMPARE(capabilities.contains(NotificationManager::HINT_CLASS), QBool(true));
+    QCOMPARE(capabilities.contains(NotificationManager::HINT_ICON), QBool(true));
+    QCOMPARE(capabilities.contains(NotificationManager::HINT_ITEM_COUNT), QBool(true));
+    QCOMPARE(capabilities.contains(NotificationManager::HINT_TIMESTAMP), QBool(true));
+    QCOMPARE(capabilities.contains(NotificationManager::HINT_PREVIEW_ICON), QBool(true));
+    QCOMPARE(capabilities.contains(NotificationManager::HINT_PREVIEW_BODY), QBool(true));
+    QCOMPARE(capabilities.contains(NotificationManager::HINT_PREVIEW_SUMMARY), QBool(true));
+    QCOMPARE(capabilities.contains("x-nemo-remote-action"), QBool(true));
+    QCOMPARE(capabilities.contains(NotificationManager::HINT_USER_REMOVABLE), QBool(true));
+    QCOMPARE(capabilities.contains(NotificationManager::HINT_GENERIC_TEXT_TRANSLATION_ID), QBool(true));
+    QCOMPARE(capabilities.contains(NotificationManager::HINT_GENERIC_TEXT_TRANSLATION_CATALOGUE), QBool(true));
 }
 
 void Ut_NotificationManager::testAddingNotification()
@@ -457,7 +477,7 @@ void Ut_NotificationManager::testAddingNotification()
     QSignalSpy spy(manager, SIGNAL(notificationModified(uint)));
     QVariantHash hints;
     hints.insert("hint", "value");
-    uint id = manager->Notify("appName", 0, "appIcon", "summary", "body", QStringList() << "action1" << "action2", hints, 1);
+    uint id = manager->Notify("appName", 0, "appIcon", "summary", "body", QStringList() << "action" << "Action", hints, 1);
     Notification *notification = manager->notification(id);
     QCOMPARE(disconnect(notification, SIGNAL(actionInvoked(QString)), manager, SLOT(invokeAction(QString))), true);
     QCOMPARE(spy.count(), 1);
@@ -476,9 +496,9 @@ void Ut_NotificationManager::testAddingNotification()
     QCOMPARE(qSqlQueryAddBindValue.at(4), QVariant("body"));
     QCOMPARE(qSqlQueryAddBindValue.at(5).toInt(), 1);
     QCOMPARE(qSqlQueryAddBindValue.at(6).toUInt(), id);
-    QCOMPARE(qSqlQueryAddBindValue.at(7), QVariant("action1"));
+    QCOMPARE(qSqlQueryAddBindValue.at(7), QVariant("action"));
     QCOMPARE(qSqlQueryAddBindValue.at(8).toUInt(), id);
-    QCOMPARE(qSqlQueryAddBindValue.at(9), QVariant("action2"));
+    QCOMPARE(qSqlQueryAddBindValue.at(9), QVariant("Action"));
     QCOMPARE(qSqlQueryAddBindValue.at(10).toUInt(), id);
     QCOMPARE(qSqlQueryAddBindValue.at(11), QVariant("hint"));
     QCOMPARE(qSqlQueryAddBindValue.at(12), QVariant("value"));
@@ -490,8 +510,8 @@ void Ut_NotificationManager::testAddingNotification()
     QCOMPARE(notification->summary(), QString("summary"));
     QCOMPARE(notification->body(), QString("body"));
     QCOMPARE(notification->actions().count(), 2);
-    QCOMPARE(notification->actions().at(0), QString("action1"));
-    QCOMPARE(notification->actions().at(1), QString("action2"));
+    QCOMPARE(notification->actions().at(0), QString("action"));
+    QCOMPARE(notification->actions().at(1), QString("Action"));
     QCOMPARE(notification->hints().value("hint"), QVariant("value"));
     QCOMPARE(notification->hints().value(NotificationManager::HINT_TIMESTAMP).type(), QVariant::DateTime);
 }
@@ -646,12 +666,12 @@ void Ut_NotificationManager::testUninstallingCategoryDefinitionRemovesNotificati
     QCOMPARE(manager->notification(id2), (Notification *)0);
 }
 
-void Ut_NotificationManager::testActionIsInvokedIfActionIsDefined()
+void Ut_NotificationManager::testActionIsInvokedIfDefined()
 {
     // Add two notifications, only the first one with an action named "action1"
     NotificationManager *manager = NotificationManager::instance();
-    uint id1 = manager->Notify("app1", 0, QString(), QString(), QString(), QStringList() << "action1", QVariantHash(), 0);
-    uint id2 = manager->Notify("app2", 0, QString(), QString(), QString(), QStringList() << "action2", QVariantHash(), 0);
+    uint id1 = manager->Notify("app1", 0, QString(), QString(), QString(), QStringList() << "action1" << "Action 1", QVariantHash(), 0);
+    uint id2 = manager->Notify("app2", 0, QString(), QString(), QString(), QStringList() << "action2" << "Action 2", QVariantHash(), 0);
     Notification *notification1 = manager->notification(id1);
     Notification *notification2 = manager->notification(id2);
     connect(this, SIGNAL(actionInvoked(QString)), notification1, SIGNAL(actionInvoked(QString)));
@@ -665,6 +685,39 @@ void Ut_NotificationManager::testActionIsInvokedIfActionIsDefined()
     QCOMPARE(spy.last().at(1).toString(), QString("action1"));
 }
 
+void Ut_NotificationManager::testActionIsNotInvokedIfIncomplete()
+{
+    // Add two notifications, the first one with an incomplete action named "action1"
+    NotificationManager *manager = NotificationManager::instance();
+    uint id1 = manager->Notify("app1", 0, QString(), QString(), QString(), QStringList() << "action1", QVariantHash(), 0);
+    uint id2 = manager->Notify("app2", 0, QString(), QString(), QString(), QStringList() << "action2" << "Action 2", QVariantHash(), 0);
+    Notification *notification1 = manager->notification(id1);
+    Notification *notification2 = manager->notification(id2);
+    connect(this, SIGNAL(actionInvoked(QString)), notification1, SIGNAL(actionInvoked(QString)));
+    connect(this, SIGNAL(actionInvoked(QString)), notification2, SIGNAL(actionInvoked(QString)));
+
+    // Make both notifications emit the actionInvoked() signal for action "action1"; no action should be invoked
+    QSignalSpy spy(manager, SIGNAL(ActionInvoked(uint, QString)));
+    emit actionInvoked("action1");
+    QCOMPARE(spy.count(), 0);
+}
+
+void Ut_NotificationManager::testRemoteActionIsInvokedIfDefined()
+{
+    // Add a notifications with an action named "action"
+    NotificationManager *manager = NotificationManager::instance();
+    QVariantHash hints;
+    hints.insert(QString(NotificationManager::HINT_REMOTE_ACTION_PREFIX) + "action", "a b c d");
+    uint id = manager->Notify("app", 0, QString(), QString(), QString(), QStringList(), hints, 0);
+    Notification *notification = manager->notification(id);
+    connect(this, SIGNAL(actionInvoked(QString)), notification, SIGNAL(actionInvoked(QString)));
+
+    // Invoking the notification should trigger the remote action
+    emit actionInvoked("action");
+    QCOMPARE(mRemoteActionTrigger.count(), 1);
+    QCOMPARE(mRemoteActionTrigger.last(), hints.value(QString(NotificationManager::HINT_REMOTE_ACTION_PREFIX) + "action").toString());
+}
+
 void Ut_NotificationManager::testInvokingActionRemovesNotificationIfUserRemovable()
 {
     // Add three notifications with user removability not set, set to true and set to false
@@ -674,9 +727,9 @@ void Ut_NotificationManager::testInvokingActionRemovesNotificationIfUserRemovabl
     QVariantHash hints3;
     hints2.insert(NotificationManager::HINT_USER_REMOVABLE, true);
     hints3.insert(NotificationManager::HINT_USER_REMOVABLE, false);
-    uint id1 = manager->Notify("app1", 0, QString(), QString(), QString(), QStringList() << "action", hints1, 0);
-    uint id2 = manager->Notify("app2", 0, QString(), QString(), QString(), QStringList() << "action", hints2, 0);
-    uint id3 = manager->Notify("app3", 0, QString(), QString(), QString(), QStringList() << "action", hints3, 0);
+    uint id1 = manager->Notify("app1", 0, QString(), QString(), QString(), QStringList(), hints1, 0);
+    uint id2 = manager->Notify("app2", 0, QString(), QString(), QString(), QStringList(), hints2, 0);
+    uint id3 = manager->Notify("app3", 0, QString(), QString(), QString(), QStringList(), hints3, 0);
     Notification *notification1 = manager->notification(id1);
     Notification *notification2 = manager->notification(id2);
     Notification *notification3 = manager->notification(id3);

--- a/tests/ut_notificationmanager/ut_notificationmanager.h
+++ b/tests/ut_notificationmanager/ut_notificationmanager.h
@@ -40,7 +40,9 @@ private slots:
     void testServerInformation();
     void testModifyingCategoryDefinitionUpdatesNotifications();
     void testUninstallingCategoryDefinitionRemovesNotifications();
-    void testActionIsInvokedIfActionIsDefined();
+    void testActionIsInvokedIfDefined();
+    void testActionIsNotInvokedIfIncomplete();
+    void testRemoteActionIsInvokedIfDefined();
     void testInvokingActionRemovesNotificationIfUserRemovable();
 
 signals:

--- a/tests/ut_notificationmanager/ut_notificationmanager.pro
+++ b/tests/ut_notificationmanager/ut_notificationmanager.pro
@@ -1,7 +1,9 @@
 include(../common.pri)
 TARGET = ut_notificationmanager
 INCLUDEPATH += $$NOTIFICATIONSRCDIR
+CONFIG += link_pkgconfig
 QT += sql dbus
+PKGCONFIG += mlite
 
 # unit test and unit
 SOURCES += \


### PR DESCRIPTION
The desktop notification specification only specifies a D-Bus signal which is sent when a notification action is invoked. This requires the target process to be running in order to catch the D-Bus signal. In a mobile device the target application is not necessarily running. This patch implements a Nemo hint which allows D-Bus calls to be associated with actions like in Harmattan. This way the target application can be started on demand.
