### PR TITLE
Battery status indicator backend

### DIFF
--- a/plugin/lipstickplugin.cpp
+++ b/plugin/lipstickplugin.cpp
@@ -21,6 +21,8 @@
 #include <components/switchermodel.h>
 #include <components/switcherpixmapitem.h>
 #include <components/statusbar.h>
+#include <components/statusindicator.h>
+#include <components/batterystatusindicator.h>
 #include <components/windowmanager.h>
 #include <components/windowinfo.h>
 #include <notifications/notificationlistmodel.h>
@@ -38,6 +40,8 @@ void LipstickPlugin::registerTypes(const char *uri)
     qmlRegisterType<SwitcherModel>("org.nemomobile.lipstick", 0, 1, "SwitcherModel");
     qmlRegisterType<SwitcherPixmapItem>("org.nemomobile.lipstick", 0, 1, "SwitcherPixmapItem");
     qmlRegisterType<StatusBar>("org.nemomobile.lipstick", 0, 1, "StatusBar");
+    qmlRegisterType<StatusIndicator>("org.nemomobile.lipstick", 0, 1, "StatusIndicator");
+    qmlRegisterType<BatteryStatusIndicator>("org.nemomobile.lipstick", 0, 1, "BatteryStatusIndicator");
     qmlRegisterType<NotificationListModel>("org.nemomobile.lipstick", 0, 1, "NotificationListModel");
     qmlRegisterUncreatableType<WindowInfo>("org.nemomobile.lipstick", 0, 1, "WindowInfo", "This type is initialized by SwitcherModel");
     qmlRegisterUncreatableType<LauncherItem>("org.nemomobile.lipstick", 0, 1, "LauncherItem", "This type is initialized by LauncherModel");

--- a/plugin/plugin.pro
+++ b/plugin/plugin.pro
@@ -2,7 +2,8 @@ TEMPLATE = lib
 TARGET = lipstickplugin
 VERSION = 0.1
 
-CONFIG += qt plugin
+CONFIG += qt plugin link_pkgconfig
+PKGCONFIG += contextsubscriber-1.0
 QT += core gui declarative
 
 INSTALLS = target qmldirfile
@@ -12,7 +13,8 @@ target.path = $$[QT_INSTALL_IMPORTS]/org/nemomobile/lipstick
 
 DEPENDPATH += "../src"
 INCLUDEPATH += "../src"
-LIBS += -L"../src" -llipstick
+QMAKE_LIBDIR = ../../src
+LIBS = -llipstick
 
 HEADERS += \
     lipstickplugin.h

--- a/src/components/batterystatusindicator.cpp
+++ b/src/components/batterystatusindicator.cpp
@@ -1,0 +1,63 @@
+/***************************************************************************
+**
+** Copyright (C) 2012 Jolla Ltd.
+** Contact: Robin Burchell <robin.burchell@jollamobile.com>
+**
+** This file is part of lipstick.
+**
+** This library is free software; you can redistribute it and/or
+** modify it under the terms of the GNU Lesser General Public
+** License version 2.1 as published by the Free Software Foundation
+** and appearing in the file LICENSE.LGPL included in the packaging
+** of this file.
+**
+****************************************************************************/
+
+#include <contextproperty.h>
+#include "batterystatusindicator.h"
+
+static const char *BATTERY_MODE_NORMAL = "";
+static const char *BATTERY_MODE_CHARGING = "Charging";
+static const char *BATTERY_MODE_POWERSAVE = "PowerSave";
+static const char *BATTERY_MODE_POWERSAVE_AND_CHARGING = "PowerSaveCharging";
+
+BatteryStatusIndicator::BatteryStatusIndicator(QObject *parent) :
+    StatusIndicator(parent),
+    batteryChargePercentageContextProperty(createContextProperty("Battery.ChargePercentage")),
+    batteryIsChargingContextProperty(createContextProperty("Battery.IsCharging")),
+    systemPowerSaveModeContextProperty(createContextProperty("System.PowerSaveMode"))
+{
+    connect(batteryChargePercentageContextProperty, SIGNAL(valueChanged()), this, SLOT(setValue()));
+    connect(batteryIsChargingContextProperty, SIGNAL(valueChanged()), this, SLOT(setMode()));
+    connect(systemPowerSaveModeContextProperty, SIGNAL(valueChanged()), this, SLOT(setMode()));
+
+    setMode();
+    setValue();
+}
+
+void BatteryStatusIndicator::setValue()
+{
+    // valueList must contain a "battery empty" image and images for different battery levels
+    int images = valueList().count() - 1;
+
+    // Calculate the amount of bars for the current charge percentage
+    int percentage = qMax(qMin(batteryChargePercentageContextProperty->value().toInt(), 100), 0);
+    int image = qMin(images * percentage / 100, images - 1);
+
+    if (batteryIsChargingContextProperty->value().toBool()) {
+        // While charging don't use the "battery empty" image, so skip it with image + 1, but always animate at least one bar, so don't add 1 if the battery is almost full
+        setInitialValueIndex(image < images - 1 ? (image + 1) : image);
+    } else {
+        // While not charging use the "battery empty" icon when 0 bars remaining, otherwise skip it with remainingBars + 1
+        setInitialValueIndex(image == 0 ? 0 : (image + 1));
+    }
+}
+
+void BatteryStatusIndicator::setMode()
+{
+    if (batteryIsChargingContextProperty->value().toBool()) {
+        StatusIndicator::setMode(systemPowerSaveModeContextProperty->value().toBool() ? BATTERY_MODE_POWERSAVE_AND_CHARGING : BATTERY_MODE_CHARGING);
+    } else {
+        StatusIndicator::setMode(systemPowerSaveModeContextProperty->value().toBool() ? BATTERY_MODE_POWERSAVE : BATTERY_MODE_NORMAL);
+    }
+}

--- a/src/components/batterystatusindicator.h
+++ b/src/components/batterystatusindicator.h
@@ -1,0 +1,59 @@
+/***************************************************************************
+**
+** Copyright (C) 2012 Jolla Ltd.
+** Contact: Robin Burchell <robin.burchell@jollamobile.com>
+**
+** This file is part of lipstick.
+**
+** This library is free software; you can redistribute it and/or
+** modify it under the terms of the GNU Lesser General Public
+** License version 2.1 as published by the Free Software Foundation
+** and appearing in the file LICENSE.LGPL included in the packaging
+** of this file.
+**
+****************************************************************************/
+
+#ifndef BATTERYSTATUSINDICATOR_H
+#define BATTERYSTATUSINDICATOR_H
+
+#include "statusindicator.h"
+
+/*!
+ * A status indicator for showing the battery charge level or
+ * battery charging animation.
+ */
+class LIPSTICK_EXPORT BatteryStatusIndicator : public StatusIndicator
+{
+    Q_OBJECT
+
+public:
+    /*!
+     * Constructs a BatteryStatusIndicator.
+     *
+     * \param parent parent object
+     */
+    explicit BatteryStatusIndicator(QObject *parent = 0);
+
+private slots:
+    //! Sets the value of the indicator based on the battery level
+    void setValue();
+
+    //! Sets the mode of the indicator based on charging and power saving states
+    void setMode();
+
+private:
+    //! The average charge level of the currently connected batteries. Expressed as percentage of the maximum charge level.
+    ContextProperty *batteryChargePercentageContextProperty;
+
+    //! Whether or not the device is currently charging at least one of its batteries.
+    ContextProperty *batteryIsChargingContextProperty;
+
+    //! A boolean indicating whether or not power save mode is enabled.
+    ContextProperty *systemPowerSaveModeContextProperty;
+
+#ifdef UNIT_TEST
+    friend class Ut_BatteryStatusIndicator;
+#endif
+};
+
+#endif // BATTERYSTATUSINDICATOR_H

--- a/src/components/statusindicator.cpp
+++ b/src/components/statusindicator.cpp
@@ -1,0 +1,151 @@
+/***************************************************************************
+**
+** Copyright (C) 2012 Jolla Ltd.
+** Contact: Robin Burchell <robin.burchell@jollamobile.com>
+**
+** This file is part of lipstick.
+**
+** This library is free software; you can redistribute it and/or
+** modify it under the terms of the GNU Lesser General Public
+** License version 2.1 as published by the Free Software Foundation
+** and appearing in the file LICENSE.LGPL included in the packaging
+** of this file.
+**
+****************************************************************************/
+
+#include <contextproperty.h>
+#include <QTimeLine>
+#include "statusindicator.h"
+
+StatusIndicator::StatusIndicator(QObject *parent) :
+    QObject(parent),
+    animationDuration_(0),
+    isOnDisplay_(true),
+    animationTimeLine(new QTimeLine(1000, this)),
+    valueIndex_(0)
+{
+    animationTimeLine->setCurveShape(QTimeLine::LinearCurve);
+    animationTimeLine->setLoopCount(0);
+    connect(animationTimeLine, SIGNAL(frameChanged(int)), this, SLOT(setCurrentValueIndex(int)));
+}
+
+QString StatusIndicator::mode() const
+{
+    return mode_;
+}
+
+void StatusIndicator::setMode(const QString &mode)
+{
+    mode_ = mode;
+    if (isOnDisplay_) {
+        emit modeChanged();
+    }
+}
+
+QString StatusIndicator::value() const
+{
+    return value_;
+}
+
+void StatusIndicator::setValue(const QString &value)
+{
+    value_ = value;
+    if (isOnDisplay_) {
+        emit valueChanged();
+    }
+}
+
+void StatusIndicator::setValueList(const QStringList &valueList)
+{
+    valueList_ = valueList;
+    setInitialValueIndex(valueIndex_);
+}
+
+QStringList StatusIndicator::valueList() const
+{
+    return valueList_;
+}
+
+void StatusIndicator::setAnimationDuration(int animationDuration)
+{
+    animationDuration_ = animationDuration;
+    if (isOnDisplay_) {
+        emit animationDurationChanged();
+    }
+    setAnimationTimeLineState();
+}
+
+int StatusIndicator::animationDuration() const
+{
+    return animationDuration_;
+}
+
+void StatusIndicator::setIsOnDisplay(bool isOnDisplay)
+{
+    isOnDisplay_ = isOnDisplay;
+    if (isOnDisplay_) {
+        foreach(ContextProperty *property, contextProperties) {
+            property->blockSignals(false);
+            property->subscribe();
+        }
+        emit subscriptionMade();
+        emit modeChanged();
+        emit valueChanged();
+    } else {
+        foreach(ContextProperty *property, contextProperties) {
+            property->unsubscribe();
+            property->blockSignals(true);
+        }
+    }
+    setAnimationTimeLineState();
+    emit isOnDisplayChanged();
+}
+
+bool StatusIndicator::isOnDisplay() const
+{
+    return isOnDisplay_;
+}
+
+ContextProperty *StatusIndicator::createContextProperty(const QString &key)
+{
+    ContextProperty *property = new ContextProperty(key, this);
+    contextProperties.append(property);
+    connect(this, SIGNAL(subscriptionMade()), property, SIGNAL(valueChanged()));
+    if (isOnDisplay_) {
+        property->subscribe();
+    } else {
+        property->blockSignals(true);
+    }
+    return property;
+}
+
+void StatusIndicator::setInitialValueIndex(int index)
+{
+    valueIndex_ = qMax(qMin(index, valueList_.count() - 1), 0);
+    setCurrentValueIndex(valueIndex_);
+    setAnimationTimeLineState();
+}
+
+void StatusIndicator::setCurrentValueIndex(int index)
+{
+    setValue(valueList_.isEmpty() ? QString() : valueList_.at(qMax(qMin(index, valueList_.count() - 1), 0)));
+}
+
+void StatusIndicator::setAnimationTimeLineState()
+{
+    bool animate = isOnDisplay_ ? (animationDuration_ > 0 && valueList_.count() > 1) : false;
+
+    if (animate) {
+        int frames = valueList_.count() - valueIndex_;
+        int loopDuration = animationDuration_ * frames / (valueList_.isEmpty() ? 1 : valueList_.count());
+        animationTimeLine->setFrameRange(valueIndex_, valueList_.count());
+        animationTimeLine->setDuration(loopDuration);
+        animationTimeLine->setUpdateInterval(animationDuration_ / valueList_.count());
+    }
+
+    if (animate && animationTimeLine->state() == QTimeLine::NotRunning) {
+        animationTimeLine->start();
+    } else if (!animate && animationTimeLine->state() == QTimeLine::Running) {
+        animationTimeLine->stop();
+    }    
+}

--- a/src/components/statusindicator.h
+++ b/src/components/statusindicator.h
@@ -1,0 +1,204 @@
+/***************************************************************************
+**
+** Copyright (C) 2012 Jolla Ltd.
+** Contact: Robin Burchell <robin.burchell@jollamobile.com>
+**
+** This file is part of lipstick.
+**
+** This library is free software; you can redistribute it and/or
+** modify it under the terms of the GNU Lesser General Public
+** License version 2.1 as published by the Free Software Foundation
+** and appearing in the file LICENSE.LGPL included in the packaging
+** of this file.
+**
+****************************************************************************/
+
+#ifndef STATUSINDICATOR_H
+#define STATUSINDICATOR_H
+
+#include <QStringList>
+#include "lipstickglobal.h"
+
+class ContextProperty;
+class QTimeLine;
+
+/*!
+ * StatusIndicator provides data for displaying image or text based status
+ * indicators in the status indicator area of the home screen. The indicator
+ * can display a single value from a list of values or animate through a
+ * range of values. The indicator may set different modes which allows the
+ * view component to define different behaviors for each mode.
+ */
+class LIPSTICK_EXPORT StatusIndicator : public QObject
+{
+    Q_OBJECT
+    Q_PROPERTY(QString mode READ mode NOTIFY modeChanged)
+    Q_PROPERTY(QString value READ value NOTIFY valueChanged)
+    Q_PROPERTY(QStringList valueList READ valueList WRITE setValueList NOTIFY valueChanged)
+    Q_PROPERTY(int animationDuration READ animationDuration WRITE setAnimationDuration NOTIFY animationDurationChanged)
+    Q_PROPERTY(bool isOnDisplay READ isOnDisplay WRITE setIsOnDisplay NOTIFY isOnDisplayChanged)
+
+public:
+    /*!
+     * Constructs a StatusIndicator.
+     *
+     * \param parent parent object
+     */
+    explicit StatusIndicator(QObject *parent = 0);
+
+    /*!
+     * Returns the current mode of the indicator.
+     *
+     * \return the current mode of the indicator
+     */
+    QString mode() const;
+
+    /*!
+     * Returns the current value of the indicator.
+     *
+     * \return the current value of the indicator
+     */
+    QString value() const;
+
+    /*!
+     * Sets the list of possible values for the indicator.
+     *
+     * \param valueList a list of possible values for the indicator
+     */
+    void setValueList(const QStringList &valueList);
+
+    /*!
+     * Returns the list of possible values for the indicator.
+     *
+     * \return the list of possible values for the indicator
+     */
+    QStringList valueList() const;
+
+    /*!
+     * Sets the total duration of the animation for all values on the value
+     * list in milliseconds.
+     *
+     * \param animationDuration the number of milliseconds to loop all values on the value list in
+     */
+    void setAnimationDuration(int animationDuration);
+
+    /*!
+     * Returns the total duration of the animation for all values on the value
+     * list in milliseconds.
+     *
+     * \return the number of milliseconds to loop all values on the value list in
+     */
+    int animationDuration() const;
+
+    /*!
+     * Sets whether the indicator should be considered to be on display or not.
+     * Property notification signals and animations are enabled and disabled
+     * based on this information.
+     *
+     * \param isOnDisplay \c true if the indicator should be considered to be on display, \c false otherwise
+     */
+    void setIsOnDisplay(bool isOnDisplay);
+
+    /*!
+     * Returns whether the indicator should be considered to be on display or not.
+     *
+     * \return \c true if the indicator should be considered to be on display, \c false otherwise
+     */
+    bool isOnDisplay() const;
+
+signals:
+    //! Emitted when the mode has changed
+    void modeChanged();
+
+    //! Emitted when the value has changed
+    void valueChanged();
+
+    //! Emitted when the animation duration has changed
+    void animationDurationChanged();
+
+    //! Emitted when the visibility has changed
+    void isOnDisplayChanged();
+
+    //! Emitted when a subscription to the context items has been made
+    void subscriptionMade();
+
+protected:
+    /*!
+     * Returns a context property monitoring the specified context key.
+     * StatusIndicator takes ownership of the context property.
+     *
+     * \param key key of the context property to be monitored
+     * \return a ContextProperty monitoring the specified context key
+     */
+    ContextProperty *createContextProperty(const QString &key);
+
+    /*!
+     * Sets the mode of the status indicator and emits the modeChanged() signal.
+     *
+     * \param mode the mode of the status indicator
+     */
+    void setMode(const QString &mode);
+
+    /*!
+     * Sets the index of the value to start iterating values from.
+     * If the animation duration is zero, only the value in this index will be
+     * used as the value of the indicator. Otherwise the value of the
+     * indicator animates from this index to the end of the value list.
+     *
+     * \param index the index of the value to start iterating values from
+     */
+    void setInitialValueIndex(int index);
+
+private slots:
+    /*!
+     * Sets the index of the value to be used as the value of the status
+     * indicator. Calls setValue() with the value in the given index.
+     *
+     * \param index the index of the value to use as the value of the status indicator
+     */
+    void setCurrentValueIndex(int index);
+
+private:
+    /*!
+     * Sets the value of the status indicator and emits the valueChanged() signal.
+     *
+     * \param value the value of the status indicator
+     */
+    void setValue(const QString &value);
+
+    /*!
+     * Sets the duration and range of the status indicator's animation and
+     * starts or stops the animation based on the defined state.
+     */
+    void setAnimationTimeLineState();
+
+    //! The current mode of the indicator
+    QString mode_;
+
+    //! The current value of the indicator
+    QString value_;
+
+    //! The list of possible values
+    QStringList valueList_;
+
+    //! Duration of the animation
+    int animationDuration_;
+
+    //! Whether the indicator should be considered to be on display or not
+    bool isOnDisplay_;
+
+    //! A list of context properties the indicator is tracking
+    QList<ContextProperty *> contextProperties;
+
+    //! Timeline for the animation
+    QTimeLine *animationTimeLine;
+
+    //! The index of the value in the value list
+    int valueIndex_;
+
+#ifdef UNIT_TEST
+    friend class Ut_StatusIndicator;
+#endif
+};
+
+#endif // STATUSINDICATOR_H

--- a/src/src.pro
+++ b/src/src.pro
@@ -6,7 +6,8 @@ VERSION = 0.1
 
 DEFINES += LIPSTICK_BUILD_LIBRARY DEBUG_NOTIFICATIONS
 
-CONFIG += qt
+CONFIG += qt link_pkgconfig
+PKGCONFIG += contextsubscriber-1.0
 INSTALLS = target
 target.path = $$[QT_INSTALL_LIBS]
 
@@ -46,7 +47,9 @@ HEADERS += \
     notifications/notificationmanageradaptor.h \
     notifications/notification.h \
     notifications/categorydefinitionstore.h \
-    notifications/notificationlistmodel.h
+    notifications/notificationlistmodel.h \
+    components/statusindicator.h \
+    components/batterystatusindicator.h
 
 SOURCES += \
     homeapplication.cpp \
@@ -68,7 +71,9 @@ SOURCES += \
     notifications/notificationmanageradaptor.cpp \
     notifications/notification.cpp \
     notifications/categorydefinitionstore.cpp \
-    notifications/notificationlistmodel.cpp
+    notifications/notificationlistmodel.cpp \
+    components/statusindicator.cpp \
+    components/batterystatusindicator.cpp
 
 CONFIG += link_pkgconfig mobility qt warn_on depend_includepath qmake_cache target_qt
 MOBILITY += sensors

--- a/tests/common.pri
+++ b/tests/common.pri
@@ -1,5 +1,6 @@
 SRCDIR = ../../src
 NOTIFICATIONSRCDIR = $$SRCDIR/notifications
+COMPONENTSRCDIR = $$SRCDIR/components
 STUBSDIR = ../stubs
 COMMONDIR = ../common
 INCLUDEPATH += $$SRCDIR $$STUBSDIR

--- a/tests/tests.pro
+++ b/tests/tests.pro
@@ -1,5 +1,5 @@
 TEMPLATE = subdirs
-SUBDIRS = ut_categorydefinitionstore ut_notification ut_notificationmanager ut_notificationlistmodel
+SUBDIRS = ut_categorydefinitionstore ut_notification ut_notificationmanager ut_notificationlistmodel ut_statusindicator ut_batterystatusindicator
 
 support_files.commands += $$PWD/gen-tests-xml.sh > $$OUT_PWD/tests.xml
 support_files.target = support_files

--- a/tests/ut_batterystatusindicator/.gitignore
+++ b/tests/ut_batterystatusindicator/.gitignore
@@ -1,0 +1,1 @@
+ut_batterystatusindicator

--- a/tests/ut_batterystatusindicator/ut_batterystatusindicator.cpp
+++ b/tests/ut_batterystatusindicator/ut_batterystatusindicator.cpp
@@ -1,0 +1,128 @@
+/***************************************************************************
+**
+** Copyright (C) 2012 Jolla Ltd.
+** Contact: Robin Burchell <robin.burchell@jollamobile.com>
+**
+** This file is part of lipstick.
+**
+** This library is free software; you can redistribute it and/or
+** modify it under the terms of the GNU Lesser General Public
+** License version 2.1 as published by the Free Software Foundation
+** and appearing in the file LICENSE.LGPL included in the packaging
+** of this file.
+**
+****************************************************************************/
+
+#include <QtTest/QtTest>
+#include <contextproperty.h>
+#include "ut_batterystatusindicator.h"
+#include "batterystatusindicator.h"
+
+// ContextProperty stubs
+QVariantHash contextPropertyValues;
+QVariant ContextProperty::value(const QVariant &def) const
+{
+    return contextPropertyValues.value(key(), def);
+}
+
+QVariant ContextProperty::value() const
+{
+    return contextPropertyValues.value(key());
+}
+
+QSet<ContextProperty *> contextPropertySubscriptions;
+void ContextProperty::subscribe() const
+{
+    contextPropertySubscriptions.insert(const_cast<ContextProperty *>(this));
+}
+
+void ContextProperty::unsubscribe() const
+{
+    contextPropertySubscriptions.remove(const_cast<ContextProperty *>(this));
+}
+
+ContextProperty *contextProperty(const QString &key)
+{
+    foreach (ContextProperty *contextProperty, contextPropertySubscriptions) {
+        if (contextProperty->key() == key) {
+            return contextProperty;
+        }
+    }
+    return 0;
+}
+
+void Ut_BatteryStatusIndicator::testConstruction()
+{
+    contextPropertyValues.insert("Battery.ChargePercentage", 53);
+    contextPropertyValues.insert("Battery.IsCharging", false);
+    contextPropertyValues.insert("System.PowerSaveMode", false);
+
+    QObject parent;
+    BatteryStatusIndicator statusIndicator(&parent);
+    QCOMPARE(statusIndicator.parent(), &parent);
+    QCOMPARE(statusIndicator.mode(), QString());
+    QCOMPARE(contextPropertySubscriptions.count(), 3);
+    ContextProperty *batteryChargeBarsContextProperty = contextProperty("Battery.ChargePercentage");
+    ContextProperty *batteryIsChargingContextProperty = contextProperty("Battery.IsCharging");
+    ContextProperty *systemPowerSaveModeContextProperty = contextProperty("System.PowerSaveMode");
+    QCOMPARE(disconnect(batteryChargeBarsContextProperty, SIGNAL(valueChanged()), &statusIndicator, SLOT(setValue())), true);
+    QCOMPARE(disconnect(batteryIsChargingContextProperty, SIGNAL(valueChanged()), &statusIndicator, SLOT(setMode())), true);
+    QCOMPARE(disconnect(systemPowerSaveModeContextProperty, SIGNAL(valueChanged()), &statusIndicator, SLOT(setMode())), true);
+}
+
+void Ut_BatteryStatusIndicator::testSetMode_data()
+{
+    QTest::addColumn<bool>("batteryIsCharging");
+    QTest::addColumn<bool>("systemPowerSaveMode");
+    QTest::addColumn<QString>("mode");
+
+    QTest::newRow("Battery is not charging, power save mode disabled") << false << false << QString();
+    QTest::newRow("Battery is not charging, power save mode enabled") << false << true << QString("PowerSave");
+    QTest::newRow("Battery is charging, power save mode disabled") << true << false << QString("Charging");
+    QTest::newRow("Battery is charging, power save mode enabled") << true << true << QString("PowerSaveCharging");
+}
+
+void Ut_BatteryStatusIndicator::testSetMode()
+{
+    QFETCH(bool, batteryIsCharging);
+    QFETCH(bool, systemPowerSaveMode);
+    QFETCH(QString, mode);
+
+    BatteryStatusIndicator statusIndicator;
+    contextPropertyValues.insert("Battery.IsCharging", batteryIsCharging);
+    contextPropertyValues.insert("System.PowerSaveMode", systemPowerSaveMode);
+    statusIndicator.setMode();
+    QCOMPARE(statusIndicator.mode(), mode);
+}
+
+void Ut_BatteryStatusIndicator::testSetValue_data()
+{
+    QTest::addColumn<int>("batteryChargePercentage");
+    QTest::addColumn<bool>("batteryIsCharging");
+    QTest::addColumn<QStringList>("valueList");
+    QTest::addColumn<QString>("value");
+
+    QTest::newRow("Battery not charging, remaining equal to maximum") << 100 << false << (QStringList() << "empty" << "value0" << "value1" << "value2") << "value2";
+    QTest::newRow("Battery not charging, remaining less than maximum") << 40 << false << (QStringList() << "empty" << "value0" << "value1" << "value2") << "value1";
+    QTest::newRow("Battery not charging, remaining 0") << 0 << false << (QStringList() << "empty" << "value0" << "value1" << "value2") << "empty";
+    QTest::newRow("Battery charging, remaining equal to maximum") << 100 << true << (QStringList() << "empty" << "value0" << "value1" << "value2") << "value1";
+    QTest::newRow("Battery charging, remaining less than maximum") << 40 << true << (QStringList() << "empty" << "value0" << "value1" << "value2") << "value1";
+    QTest::newRow("Battery charging, remaining 0") << 0 << true << (QStringList() << "empty" << "value0" << "value1" << "value2") << "value0";
+}
+
+void Ut_BatteryStatusIndicator::testSetValue()
+{
+    QFETCH(int, batteryChargePercentage);
+    QFETCH(bool, batteryIsCharging);
+    QFETCH(QStringList, valueList);
+    QFETCH(QString, value);
+
+    BatteryStatusIndicator statusIndicator;
+    contextPropertyValues.insert("Battery.ChargePercentage", batteryChargePercentage);
+    contextPropertyValues.insert("Battery.IsCharging", batteryIsCharging);
+    statusIndicator.setValueList(valueList);
+    statusIndicator.setValue();
+    QCOMPARE(statusIndicator.value(), value);
+}
+
+QTEST_MAIN(Ut_BatteryStatusIndicator)

--- a/tests/ut_batterystatusindicator/ut_batterystatusindicator.h
+++ b/tests/ut_batterystatusindicator/ut_batterystatusindicator.h
@@ -1,0 +1,32 @@
+/***************************************************************************
+**
+** Copyright (C) 2012 Jolla Ltd.
+** Contact: Robin Burchell <robin.burchell@jollamobile.com>
+**
+** This file is part of lipstick.
+**
+** This library is free software; you can redistribute it and/or
+** modify it under the terms of the GNU Lesser General Public
+** License version 2.1 as published by the Free Software Foundation
+** and appearing in the file LICENSE.LGPL included in the packaging
+** of this file.
+**
+****************************************************************************/
+#ifndef UT_BATTERYSTATUSINDICATOR_H
+#define UT_BATTERYSTATUSINDICATOR_H
+
+#include <QObject>
+
+class Ut_BatteryStatusIndicator : public QObject
+{
+    Q_OBJECT
+
+private slots:
+    void testConstruction();
+    void testSetMode_data();
+    void testSetMode();
+    void testSetValue_data();
+    void testSetValue();
+};
+
+#endif

--- a/tests/ut_batterystatusindicator/ut_batterystatusindicator.pro
+++ b/tests/ut_batterystatusindicator/ut_batterystatusindicator.pro
@@ -1,0 +1,18 @@
+include(../common.pri)
+TARGET = ut_batterystatusindicator
+INCLUDEPATH += $$COMPONENTSRCDIR
+QT += dbus
+CONFIG += qt link_pkgconfig
+PKGCONFIG += contextsubscriber-1.0
+
+# unit test and unit
+SOURCES += \
+    ut_batterystatusindicator.cpp \
+    $$COMPONENTSRCDIR/batterystatusindicator.cpp \
+    $$COMPONENTSRCDIR/statusindicator.cpp
+
+# unit test and unit
+HEADERS += \
+    ut_batterystatusindicator.h \
+    $$COMPONENTSRCDIR/batterystatusindicator.h \
+    $$COMPONENTSRCDIR/statusindicator.h

--- a/tests/ut_statusindicator/.gitignore
+++ b/tests/ut_statusindicator/.gitignore
@@ -1,0 +1,1 @@
+ut_statusindicator

--- a/tests/ut_statusindicator/ut_statusindicator.cpp
+++ b/tests/ut_statusindicator/ut_statusindicator.cpp
@@ -1,0 +1,269 @@
+/***************************************************************************
+**
+** Copyright (C) 2012 Jolla Ltd.
+** Contact: Robin Burchell <robin.burchell@jollamobile.com>
+**
+** This file is part of lipstick.
+**
+** This library is free software; you can redistribute it and/or
+** modify it under the terms of the GNU Lesser General Public
+** License version 2.1 as published by the Free Software Foundation
+** and appearing in the file LICENSE.LGPL included in the packaging
+** of this file.
+**
+****************************************************************************/
+
+#include <QtTest/QtTest>
+#include <QTimeLine>
+#include <contextproperty.h>
+#include "ut_statusindicator.h"
+#include "statusindicator.h"
+
+// QTimeLine stubs
+QTimeLine::State qTimeLineState = QTimeLine::NotRunning;
+QTimeLine::State QTimeLine::state() const
+{
+    return qTimeLineState;
+}
+
+void QTimeLine::start()
+{
+    qTimeLineState = QTimeLine::Running;
+}
+
+void QTimeLine::stop()
+{
+    qTimeLineState = QTimeLine::NotRunning;
+}
+
+int qTimeLineDuration = 0;
+void QTimeLine::setDuration(int duration)
+{
+    qTimeLineDuration = duration;
+}
+
+int qTimeLineUpdateInterval = 0;
+void QTimeLine::setUpdateInterval(int interval)
+{
+    qTimeLineUpdateInterval = interval;
+}
+
+int qTimeLineStartFrame = 0;
+int qTimeLineEndFrame = 0;
+void QTimeLine::setFrameRange(int startFrame, int endFrame)
+{
+    qTimeLineStartFrame = startFrame;
+    qTimeLineEndFrame = endFrame;
+}
+
+// ContextProperty stubs
+QSet<const ContextProperty *> contextPropertySubscriptions;
+void ContextProperty::subscribe() const
+{
+    contextPropertySubscriptions.insert(this);
+}
+
+void ContextProperty::unsubscribe() const
+{
+    contextPropertySubscriptions.remove(this);
+}
+
+void Ut_StatusIndicator::testConstruction()
+{
+    QObject parent;
+    StatusIndicator statusIndicator(&parent);
+    QCOMPARE(statusIndicator.parent(), &parent);
+    QCOMPARE(statusIndicator.animationTimeLine->curveShape(), QTimeLine::LinearCurve);
+    QCOMPARE(statusIndicator.animationTimeLine->loopCount(), 0);
+    QCOMPARE(disconnect(statusIndicator.animationTimeLine, SIGNAL(frameChanged(int)), &statusIndicator, SLOT(setCurrentValueIndex(int))), true);
+}
+
+void Ut_StatusIndicator::testGettersAndSetters()
+{
+    StatusIndicator statusIndicator;
+    QString mode("testMode");
+    QString value("testValue");
+    QStringList valueList("testValue1 testValue2");
+    int animationDuration = 123;
+    bool isOnDisplay = false;
+
+    QCOMPARE(statusIndicator.mode(), QString());
+    statusIndicator.setMode(mode);
+    QCOMPARE(statusIndicator.mode(), mode);
+
+    QCOMPARE(statusIndicator.value(), QString());
+    statusIndicator.setValue(value);
+    QCOMPARE(statusIndicator.value(), value);
+
+    QCOMPARE(statusIndicator.valueList(), QStringList());
+    statusIndicator.setValueList(valueList);
+    QCOMPARE(statusIndicator.valueList(), valueList);
+
+    QCOMPARE(statusIndicator.animationDuration(), 0);
+    statusIndicator.setAnimationDuration(animationDuration);
+    QCOMPARE(statusIndicator.animationDuration(), animationDuration);
+
+    QCOMPARE(statusIndicator.isOnDisplay(), true);
+    statusIndicator.setIsOnDisplay(isOnDisplay);
+    QCOMPARE(statusIndicator.isOnDisplay(), isOnDisplay);
+}
+
+void Ut_StatusIndicator::testPropertyNotificationSignals_data()
+{
+    QTest::addColumn<bool>("isOnDisplay");
+    QTest::addColumn<int>("signalCount");
+
+    QTest::newRow("Status indicator is on display") << true << 1;
+    QTest::newRow("Status indicator is not on display") << false << 0;
+}
+
+void Ut_StatusIndicator::testPropertyNotificationSignals()
+{
+    QFETCH(bool, isOnDisplay);
+    QFETCH(int, signalCount);
+
+    StatusIndicator statusIndicator;
+    QSignalSpy isOnDisplaySpy(&statusIndicator, SIGNAL(isOnDisplayChanged()));
+    statusIndicator.setIsOnDisplay(isOnDisplay);
+    QCOMPARE(isOnDisplaySpy.count(), 1);
+
+    QSignalSpy modeChangedSpy(&statusIndicator, SIGNAL(modeChanged()));
+    QSignalSpy valueChangedSpy(&statusIndicator, SIGNAL(valueChanged()));
+    QSignalSpy animationDurationChangedSpy(&statusIndicator, SIGNAL(animationDurationChanged()));
+    statusIndicator.setMode("testMode");
+    QCOMPARE(modeChangedSpy.count(), signalCount);
+    statusIndicator.setValue("testValue");
+    QCOMPARE(valueChangedSpy.count(), signalCount);
+    statusIndicator.setValueList(QStringList() << "testValue1" << "testValue2");
+    QCOMPARE(valueChangedSpy.count(), 2 * signalCount);
+    statusIndicator.setAnimationDuration(123);
+    QCOMPARE(animationDurationChangedSpy.count(), signalCount);
+}
+
+void Ut_StatusIndicator::testSettingInitialValueIndexSetsValueAndStaysWithinBounds()
+{
+    StatusIndicator statusIndicator;
+    statusIndicator.setValueList(QStringList() << "value0" << "value1");
+    QCOMPARE(statusIndicator.value(), QString("value0"));
+    statusIndicator.setInitialValueIndex(1);
+    QCOMPARE(statusIndicator.value(), QString("value1"));
+    statusIndicator.setInitialValueIndex(-1);
+    QCOMPARE(statusIndicator.value(), QString("value0"));
+    statusIndicator.setInitialValueIndex(2);
+    QCOMPARE(statusIndicator.value(), QString("value1"));
+    statusIndicator.setValueList(QStringList() << "newValue0" << "newValue1");
+    QCOMPARE(statusIndicator.value(), QString("newValue1"));
+    statusIndicator.setValueList(QStringList() << "value");
+    QCOMPARE(statusIndicator.value(), QString("value"));
+}
+
+void Ut_StatusIndicator::testSettingAnimationDurationSetsTimelineState()
+{
+    StatusIndicator statusIndicator;
+    statusIndicator.setValueList(QStringList() << "value0" << "value1" << "value2" << "value3");
+    statusIndicator.setAnimationDuration(4000);
+    QCOMPARE(qTimeLineStartFrame, 0);
+    QCOMPARE(qTimeLineEndFrame, 4);
+    QCOMPARE(qTimeLineDuration, 4000);
+    QCOMPARE(qTimeLineUpdateInterval, 1000);
+    QCOMPARE(qTimeLineState, QTimeLine::Running);
+
+    statusIndicator.setAnimationDuration(0);
+    QCOMPARE(qTimeLineState, QTimeLine::NotRunning);
+}
+
+void Ut_StatusIndicator::testAnimationIsDisabledWhenNotOnDisplay()
+{
+    StatusIndicator statusIndicator;
+    statusIndicator.setIsOnDisplay(false);
+    statusIndicator.setValueList(QStringList() << "value0" << "value1" << "value2" << "value3");
+    statusIndicator.setAnimationDuration(4000);
+    QCOMPARE(qTimeLineState, QTimeLine::NotRunning);
+
+    statusIndicator.setIsOnDisplay(true);
+    QCOMPARE(qTimeLineState, QTimeLine::Running);
+}
+
+void Ut_StatusIndicator::testAnimationIsDisabledWhenNotEnoughValuesToAnimate()
+{
+    StatusIndicator statusIndicator;
+    statusIndicator.setValueList(QStringList() << "value0");
+    statusIndicator.setAnimationDuration(4000);
+    QCOMPARE(qTimeLineState, QTimeLine::NotRunning);
+}
+
+void Ut_StatusIndicator::testSettingInitialValueIndexSetsAnimationLength()
+{
+    StatusIndicator statusIndicator;
+    statusIndicator.setValueList(QStringList() << "value0" << "value1" << "value2" << "value3");
+    statusIndicator.setAnimationDuration(4000);
+    statusIndicator.setInitialValueIndex(1);
+    QCOMPARE(qTimeLineStartFrame, 1);
+    QCOMPARE(qTimeLineEndFrame, 4);
+    QCOMPARE(qTimeLineDuration, 3000);
+    QCOMPARE(qTimeLineUpdateInterval, 1000);
+    QCOMPARE(qTimeLineState, QTimeLine::Running);
+}
+
+void Ut_StatusIndicator::testContextPropertyCreation()
+{
+    StatusIndicator statusIndicator;
+    ContextProperty *property1 = statusIndicator.createContextProperty("testKey1");
+    QCOMPARE(disconnect(&statusIndicator, SIGNAL(subscriptionMade()), property1, SIGNAL(valueChanged())), true);
+    QCOMPARE(contextPropertySubscriptions.contains(property1), true);
+    QCOMPARE(property1->signalsBlocked(), false);
+
+    statusIndicator.setIsOnDisplay(false);
+    ContextProperty *property2 = statusIndicator.createContextProperty("testKey2");
+    QCOMPARE(disconnect(&statusIndicator, SIGNAL(subscriptionMade()), property2, SIGNAL(valueChanged())), true);
+    QCOMPARE(contextPropertySubscriptions.contains(property2), false);
+    QCOMPARE(property2->signalsBlocked(), true);
+}
+
+void Ut_StatusIndicator::testSettingIsOnDisplaySubscribesContextProperties_data()
+{
+    QTest::addColumn<bool>("wasOnDisplay");
+    QTest::addColumn<bool>("isOnDisplay");
+    QTest::addColumn<bool>("subscribed");
+    QTest::addColumn<bool>("signalsBlocked");
+    QTest::addColumn<int>("subscriptionMadeCount");
+    QTest::addColumn<int>("modeChangedCount");
+    QTest::addColumn<int>("valueChangedCount");
+    QTest::addColumn<int>("isOnDisplayChangedCount");
+
+    QTest::newRow("Status indicator is on display") << false << true << true << false << 1 << 1 << 1 << 1;
+    QTest::newRow("Status indicator is not on display") << true << false << false << true << 0 << 0 << 0 << 1;
+}
+
+void Ut_StatusIndicator::testSettingIsOnDisplaySubscribesContextProperties()
+{
+    QFETCH(bool, wasOnDisplay);
+    QFETCH(bool, isOnDisplay);
+    QFETCH(bool, subscribed);
+    QFETCH(bool, signalsBlocked);
+    QFETCH(int, subscriptionMadeCount);
+    QFETCH(int, modeChangedCount);
+    QFETCH(int, valueChangedCount);
+    QFETCH(int, isOnDisplayChangedCount);
+
+    StatusIndicator statusIndicator;
+    statusIndicator.setIsOnDisplay(wasOnDisplay);
+    ContextProperty *property1 = statusIndicator.createContextProperty("testKey1");
+    ContextProperty *property2 = statusIndicator.createContextProperty("testKey2");
+
+    QSignalSpy subscriptionMadeSpy(&statusIndicator, SIGNAL(subscriptionMade()));
+    QSignalSpy modeChangedSpy(&statusIndicator, SIGNAL(modeChanged()));
+    QSignalSpy valueChangedSpy(&statusIndicator, SIGNAL(valueChanged()));
+    QSignalSpy isOnDisplayChangedSpy(&statusIndicator, SIGNAL(isOnDisplayChanged()));
+    statusIndicator.setIsOnDisplay(isOnDisplay);
+    QCOMPARE(contextPropertySubscriptions.contains(property1), subscribed);
+    QCOMPARE(contextPropertySubscriptions.contains(property2), subscribed);
+    QCOMPARE(property1->signalsBlocked(), signalsBlocked);
+    QCOMPARE(property2->signalsBlocked(), signalsBlocked);
+    QCOMPARE(subscriptionMadeSpy.count(), subscriptionMadeCount);
+    QCOMPARE(modeChangedSpy.count(), modeChangedCount);
+    QCOMPARE(valueChangedSpy.count(), valueChangedCount);
+    QCOMPARE(isOnDisplayChangedSpy.count(), isOnDisplayChangedCount);
+}
+
+QTEST_MAIN(Ut_StatusIndicator)

--- a/tests/ut_statusindicator/ut_statusindicator.h
+++ b/tests/ut_statusindicator/ut_statusindicator.h
@@ -1,0 +1,39 @@
+/***************************************************************************
+**
+** Copyright (C) 2012 Jolla Ltd.
+** Contact: Robin Burchell <robin.burchell@jollamobile.com>
+**
+** This file is part of lipstick.
+**
+** This library is free software; you can redistribute it and/or
+** modify it under the terms of the GNU Lesser General Public
+** License version 2.1 as published by the Free Software Foundation
+** and appearing in the file LICENSE.LGPL included in the packaging
+** of this file.
+**
+****************************************************************************/
+#ifndef UT_STATUSINDICATOR_H
+#define UT_STATUSINDICATOR_H
+
+#include <QObject>
+
+class Ut_StatusIndicator : public QObject
+{
+    Q_OBJECT
+
+private slots:
+    void testConstruction();
+    void testGettersAndSetters();
+    void testPropertyNotificationSignals_data();
+    void testPropertyNotificationSignals();
+    void testSettingInitialValueIndexSetsValueAndStaysWithinBounds();
+    void testSettingAnimationDurationSetsTimelineState();
+    void testAnimationIsDisabledWhenNotOnDisplay();
+    void testAnimationIsDisabledWhenNotEnoughValuesToAnimate();
+    void testSettingInitialValueIndexSetsAnimationLength();
+    void testContextPropertyCreation();
+    void testSettingIsOnDisplaySubscribesContextProperties_data();
+    void testSettingIsOnDisplaySubscribesContextProperties();
+};
+
+#endif

--- a/tests/ut_statusindicator/ut_statusindicator.pro
+++ b/tests/ut_statusindicator/ut_statusindicator.pro
@@ -1,0 +1,16 @@
+include(../common.pri)
+TARGET = ut_statusindicator
+INCLUDEPATH += $$COMPONENTSRCDIR
+QT += dbus
+CONFIG += qt link_pkgconfig
+PKGCONFIG += contextsubscriber-1.0
+
+# unit test and unit
+SOURCES += \
+    ut_statusindicator.cpp \
+    $$COMPONENTSRCDIR/statusindicator.cpp
+
+# unit test and unit
+HEADERS += \
+    ut_statusindicator.h \
+    $$COMPONENTSRCDIR/statusindicator.h


### PR DESCRIPTION
The StatusIndicator class provides a generic mechanism to implement status indicators
on the home screen. The indicator can display a single value from a list of values or
animate through a range of values from a list of values. The indicator may set
its mode which allows the view component to define different behaviors for different modes.
The BatteryStatusIndicator class uses these facilities to provide data for a battery
status indicator.
