### PR TITLE
expose the XAtomCache and XEventListener classes too

### DIFF
--- a/src/xtools/xatomcache.h
+++ b/src/xtools/xatomcache.h
@@ -18,10 +18,13 @@
 #ifndef ATOMCACHE_H
 #define ATOMCACHE_H
 
+#include <QByteArray>
 #include <X11/Xlib.h>
 #include <X11/Xutil.h>
 
-class AtomCache
+#include "lipstickglobal.h"
+
+class LIPSTICK_EXPORT AtomCache
 {
 public:
     static Atom atom(const QByteArray &atom);

--- a/src/xtools/xeventlistener.h
+++ b/src/xtools/xeventlistener.h
@@ -14,13 +14,14 @@
 #define XEVENTLISTENER_H_
 
 #include <X11/Xlib.h>
+#include "lipstickglobal.h"
 
 /*!
  * An interface for listening to X events.
  * Objects of this class receive X events throughout their lifecycle as the events
  * arrive.
  */
-class XEventListener
+class LIPSTICK_EXPORT XEventListener
 {
 public:
     /*!


### PR DESCRIPTION
The header files were already exposed in previous pull request. After this should work properly.
