### PR TITLE
Fix check for _NET_WM_STATE_SKIP_TASKBAR

### DIFF
--- a/src/components/windowinfo.cpp
+++ b/src/components/windowinfo.cpp
@@ -214,28 +214,18 @@ static QVector<Atom> getNetWmState(Display *display, Window window)
     ulong bytesLeft;
     uchar *propertyData = 0;
 
-    // Step 1: Get the size of the list
-    bool result = XGetWindowProperty(display, window, AtomCache::atom("_NET_WM_STATE"), 0, 0x7fffffff,
+    bool result = XGetWindowProperty(display, window, AtomCache::atom("_NET_WM_STATE"), 0, 12L,
                                      false, XA_ATOM, &actualType,
                                      &actualFormat, &propertyLength,
                                      &bytesLeft, &propertyData);
-    if (result != Success || actualType != XA_ATOM || actualFormat != 32)
-        return atomList;
-
-    XFree(propertyData);
-    atomList.resize(propertyLength);
-
-    // Step 2: Get the actual list
-    if (!XGetWindowProperty(display, window, AtomCache::atom("_NET_WM_STATE"), 0,
-                            atomList.size(), false, XA_ATOM,
-                            &actualType, &actualFormat,
-                            &propertyLength, &bytesLeft,
-                            &propertyData) == Success) {
-        qWarning("Unable to retrieve window properties: %i", (int) window);
+    if (result != Success || actualType != XA_ATOM || actualFormat != 32) {
+        if (propertyData) {
+            XFree(propertyData);
+        }
         return atomList;
     }
 
-
+    atomList.resize(propertyLength);
     if (!atomList.isEmpty())
         memcpy(atomList.data(), propertyData,
                atomList.size() * sizeof(Atom));


### PR DESCRIPTION
The property was never checked in reality.
