### PR TITLE
[lipstick] Hide in-process windows by default for WindowModel

### DIFF
--- a/src/compositor/windowmodel.cpp
+++ b/src/compositor/windowmodel.cpp
@@ -93,9 +93,9 @@ void WindowModel::componentComplete()
 /*!
     Reimplement this method to provide custom filtering.
 */
-bool WindowModel::approveWindow(LipstickCompositorWindow *)
+bool WindowModel::approveWindow(LipstickCompositorWindow *window)
 {
-    return true;
+    return window->isInProcess() == false;
 }
 
 void WindowModel::addItem(int id)


### PR DESCRIPTION
This can be overriden in a subclass if desired, but not showing
in-process windows (including the homescreen itself) is the most useful
default.
