### PR TITLE
[lipstick] Fix header inclusion.

### DIFF
--- a/src/components/launchermodel.h
+++ b/src/components/launchermodel.h
@@ -19,7 +19,7 @@
 
 #include <QObject>
 #include "launcheritem.h"
-#include "utilities/qobjectlistmodel.h"
+#include "qobjectlistmodel.h"
 #include "lipstickglobal.h"
 
 class QFileSystemWatcher;


### PR DESCRIPTION
All headers are installed in one directory and include path set when
built.
