### PR TITLE
Watch changes in .desktop files so that adding new items, modifying existing items and removing items works as expected

### DIFF
--- a/src/components/launcheritem.cpp
+++ b/src/components/launcheritem.cpp
@@ -159,3 +159,10 @@ void LauncherItem::launchApplication()
     // Launching animation will stop after 5 seconds
     QTimer::singleShot(5000, this, SLOT(disableIsLaunching()));
 }
+
+bool LauncherItem::isStillValid()
+{
+    _desktopEntry = QSharedPointer<MDesktopEntry>(new MDesktopEntry(filePath()));
+    emit this->itemChanged();
+    return isValid();
+}

--- a/src/components/launcheritem.h
+++ b/src/components/launcheritem.h
@@ -63,6 +63,7 @@ public:
     bool shouldDisplay() const;
     bool isValid() const;
     bool isLaunching() const;
+    bool isStillValid();
 
     Q_INVOKABLE void launchApplication();
 

--- a/src/components/launchermodel.h
+++ b/src/components/launchermodel.h
@@ -23,6 +23,7 @@
 #include "lipstickglobal.h"
 
 class QFileSystemWatcher;
+class QSettings;
 
 class LIPSTICK_EXPORT LauncherModel : public QObjectListModel
 {
@@ -35,8 +36,8 @@ class LIPSTICK_EXPORT LauncherModel : public QObjectListModel
     QString _settingsPath;
 
 private slots:
-    void monitoredDirectoryChanged(QString);
-    void monitoredFileChanged(QString changedPath);
+    void monitoredDirectoryChanged(const QString &changedPath);
+    void monitoredFileChanged(const QString &changedPath);
 
 public:
     explicit LauncherModel(QObject *parent = 0);
@@ -53,6 +54,9 @@ signals:
 
 private:
     void reorderItems(const QMap<int, LauncherItem *> &itemsWithPositions);
+    void loadPositions();
+    LauncherItem *itemInModel(const QString &path);
+    void addItemIfValid(const QString &path, QMap<int, LauncherItem *> &itemsWithPositions, QSettings &launcherSettings, QSettings &globalSettings);
 };
 
 #endif // LAUNCHERMODEL_H


### PR DESCRIPTION
Fixes:
- .desktop files were read before the contents were there (and never read again), so items were missing
- launcher didn't react to changes in the files
