### PR TITLE
Add fullscreenSurface property (for direct rendering)

### DIFF
--- a/rpm/lipstick-qt5.spec
+++ b/rpm/lipstick-qt5.spec
@@ -37,7 +37,7 @@ BuildRequires:  pkgconfig(ngf-qt5)
 BuildRequires:  pkgconfig(qmsystem2-qt5) >= 1.4.7
 BuildRequires:  pkgconfig(contextkit-statefs) >= 0.2.7
 BuildRequires:  qt5-qttools-linguist
-BuildRequires:  qt5-qtwayland-wayland_egl-devel >= 5.1.0+git3
+BuildRequires:  qt5-qtwayland-wayland_egl-devel >= 5.1.0+git7
 BuildRequires:  doxygen
 Conflicts:   meegotouch-systemui < 1.5.7
 Obsoletes:   libnotificationsystem0

--- a/rpm/lipstick-qt5.yaml
+++ b/rpm/lipstick-qt5.yaml
@@ -30,7 +30,7 @@ PkgConfigBR:
     - contextkit-statefs >= 0.2.7
 PkgBR:
     - qt5-qttools-linguist
-    - qt5-qtwayland-wayland_egl-devel >= 5.1.0+git3
+    - qt5-qtwayland-wayland_egl-devel >= 5.1.0+git7
     - doxygen
 Files:
     - "%config %{_sysconfdir}/dbus-1/system.d/lipstick.conf"

--- a/src/compositor/lipstickcompositor.h
+++ b/src/compositor/lipstickcompositor.h
@@ -36,6 +36,7 @@ class LIPSTICK_EXPORT LipstickCompositor : public QQuickWindow, public QWaylandC
     Q_PROPERTY(int ghostWindowCount READ ghostWindowCount NOTIFY ghostWindowCountChanged)
     Q_PROPERTY(bool homeActive READ homeActive WRITE setHomeActive NOTIFY homeActiveChanged)
     Q_PROPERTY(bool debug READ debug CONSTANT)
+    Q_PROPERTY(QWaylandSurface* fullscreenSurface READ fullscreenSurface WRITE setFullscreenSurface NOTIFY fullscreenSurfaceChanged)
 
 public:
     LipstickCompositor();
@@ -52,6 +53,9 @@ public:
 
     bool homeActive() const;
     void setHomeActive(bool);
+
+    QWaylandSurface *fullscreenSurface() const { return m_fullscreenSurface; }
+    void setFullscreenSurface(QWaylandSurface *surface);
 
     bool debug() const;
 
@@ -73,9 +77,12 @@ signals:
     void availableWinIdsChanged();
 
     void homeActiveChanged();
+    void fullscreenSurfaceChanged();
+
+protected:
+     virtual void surfaceAboutToBeDestroyed(QWaylandSurface *surface);
 
 private slots:
-    void surfaceDestroyed();
     void surfaceMapped();
     void surfaceUnmapped();
     void surfaceSizeChanged();
@@ -116,6 +123,7 @@ private:
     bool m_homeActive;
 
     QQmlComponent *m_shaderEffect;
+    QWaylandSurface *m_fullscreenSurface;
 };
 
 class LIPSTICK_EXPORT LipstickCompositorWindow : public QWaylandSurfaceItem


### PR DESCRIPTION
Only the fullscreen surface will be sent frame events,
throttling other surfaces.
