### PR TITLE
Listen to mce and repaint when we are told the display is back on.

### DIFF
--- a/src/screenlock/screenlock.cpp
+++ b/src/screenlock/screenlock.cpp
@@ -19,7 +19,11 @@
 #include <QDBusPendingCall>
 #include <QTextStream>
 #include <QCursor>
+#include <QQuickWindow>
+#include <QDebug>
+
 #include <mce/mode-names.h>
+#include <mce/dbus-names.h>
 
 #include "homeapplication.h"
 #include "screenlock.h"
@@ -33,10 +37,43 @@ ScreenLock::ScreenLock(QObject* parent) :
     eatEvents(false)
 {
     qApp->installEventFilter(this);
+
+    QDBusConnection::systemBus().connect(MCE_SERVICE,
+                                         MCE_SIGNAL_PATH,
+                                         MCE_SIGNAL_IF,
+                                         MCE_DISPLAY_SIG,
+                                         this,
+                                         SLOT(displayStatusChanged(QString)));
 }
 
 ScreenLock::~ScreenLock()
 {
+}
+
+void ScreenLock::displayStatusChanged(const QString &mode)
+{
+    static QString previousState = MCE_DISPLAY_OFF_STRING;
+
+    if (previousState != MCE_DISPLAY_OFF_STRING) {
+        // we don't care about ON to DIM transitions (for instance), just about
+        // redrawing when we see OFF => ?
+        previousState = mode;
+        return;
+    }
+
+    // force a repaint to get the contents back on the screen in the case that
+    // the framebuffer doesn't retain it
+    foreach (QWindow *win, QGuiApplication::topLevelWindows()) {
+        QQuickWindow *quickwin = qobject_cast<QQuickWindow *>(win);
+        if (!quickwin) {
+            qWarning() << Q_FUNC_INFO << "Unknown top level window " << quickwin;
+            continue;
+        }
+
+        quickwin->update();
+    }
+
+    previousState = mode;
 }
 
 int ScreenLock::tklock_open(const QString &service, const QString &path, const QString &interface, const QString &method, uint mode, bool, bool)

--- a/src/screenlock/screenlock.h
+++ b/src/screenlock/screenlock.h
@@ -112,6 +112,9 @@ signals:
     //! Emitted when the screen lock state changes
     void screenIsLocked(bool locked);
 
+private slots:
+    void displayStatusChanged(const QString &mode);
+
 private:
     enum TkLockReply {
         TkLockReplyFailed = 0,

--- a/tests/stubs/screenlock_stub.h
+++ b/tests/stubs/screenlock_stub.h
@@ -26,6 +26,7 @@ class ScreenLockStub : public StubBase {
   public:
   virtual void ScreenLockConstructor(QObject *parent);
   virtual void ScreenLockDestructor();
+  virtual void displayStatusChanged(const QString &mode);
   virtual int tklock_open(const QString &service, const QString &path, const QString &interface, const QString &method, uint mode, bool silent, bool flicker);
   virtual int tklock_close(bool silent);
   virtual void toggleScreenLockUI(bool toggle);
@@ -51,6 +52,14 @@ void ScreenLockStub::ScreenLockConstructor(QObject *parent) {
 void ScreenLockStub::ScreenLockDestructor() {
 
 }
+
+void ScreenLockStub::displayStatusChanged(const QString &mode)
+{
+  QList<ParameterBase*> params;
+  params.append( new Parameter<const QString &>(mode));
+  stubMethodEntered("displayStatusChanged",params);
+}
+
 int ScreenLockStub::tklock_open(const QString &service, const QString &path, const QString &interface, const QString &method, uint mode, bool silent, bool flicker) {
   QList<ParameterBase*> params;
   params.append( new Parameter<const QString & >(service));
@@ -146,6 +155,11 @@ ScreenLock::ScreenLock(QObject *parent) {
 
 ScreenLock::~ScreenLock() {
   gScreenLockStub->ScreenLockDestructor();
+}
+
+void ScreenLock::displayStatusChanged(const QString &mode)
+{
+    gScreenLockStub->displayStatusChanged(mode);
 }
 
 int ScreenLock::tklock_open(const QString &service, const QString &path, const QString &interface, const QString &method, uint mode, bool silent, bool flicker) {

--- a/tests/stubs/screenlockadaptor_stub.h
+++ b/tests/stubs/screenlockadaptor_stub.h
@@ -26,6 +26,7 @@ class ScreenLockAdaptorStub : public StubBase {
   public:
   virtual void ScreenLockAdaptorConstructor(ScreenLock *parent);
   virtual void ScreenLockAdaptorDestructor();
+  virtual void displayStatusChanged(const QString &mode);
   virtual int tklock_close(bool silent);
   virtual int tklock_open(const QString &service, const QString &path, const QString &interface, const QString &method, uint mode, bool silent, bool flicker);
 }; 
@@ -38,6 +39,13 @@ void ScreenLockAdaptorStub::ScreenLockAdaptorConstructor(ScreenLock *parent) {
 void ScreenLockAdaptorStub::ScreenLockAdaptorDestructor() {
 
 }
+
+void ScreenLockAdaptorStub::displayStatusChanged(const QString &mode) {
+  QList<ParameterBase*> params;
+  params.append( new Parameter<const QString & >(mode));
+  stubMethodEntered("displayStatusChanged",params);
+}
+
 int ScreenLockAdaptorStub::tklock_close(bool silent) {
   QList<ParameterBase*> params;
   params.append( new Parameter<bool >(silent));


### PR DESCRIPTION
Previously, this was somewhat handled in mcompositor and the X stack, but now we
need to repaint the screen ourselves when it is turned back on, as the screen
contents may not survive being powered off.

See for reference: https://github.com/nemomobile/mcompositor/blob/master/src/mdevicestate.cpp
