### PR TITLE
[lipstick] Support for reading supported orientations from the application's .desktop file

### DIFF
--- a/rpm/lipstick-qt5.spec
+++ b/rpm/lipstick-qt5.spec
@@ -28,7 +28,7 @@ BuildRequires:  pkgconfig(Qt5Sql)
 BuildRequires:  pkgconfig(Qt5SystemInfo)
 BuildRequires:  pkgconfig(Qt5Test)
 BuildRequires:  pkgconfig(contentaction5)
-BuildRequires:  pkgconfig(mlite5) >= 0.0.6
+BuildRequires:  pkgconfig(mlite5) >= 0.2.0
 BuildRequires:  pkgconfig(mce) >= 1.12.2
 BuildRequires:  pkgconfig(dbus-1)
 BuildRequires:  pkgconfig(dbus-glib-1)

--- a/rpm/lipstick-qt5.yaml
+++ b/rpm/lipstick-qt5.yaml
@@ -20,7 +20,7 @@ PkgConfigBR:
     - Qt5Sensors
     - Qt5Test
     - contentaction5
-    - mlite5 >= 0.0.6
+    - mlite5 >= 0.2.0
     - mce >= 1.12.2
     - dbus-1
     - dbus-glib-1

--- a/src/compositor/lipstickcompositorwindow.h
+++ b/src/compositor/lipstickcompositorwindow.h
@@ -35,6 +35,8 @@ class LIPSTICK_EXPORT LipstickCompositorWindow : public QWaylandSurfaceItem
 
     Q_PROPERTY(QRect mouseRegionBounds READ mouseRegionBounds NOTIFY mouseRegionBoundsChanged)
 
+    Q_PROPERTY(Qt::ScreenOrientations supportedOrientations READ supportedOrientations CONSTANT)
+
 public:
     LipstickCompositorWindow(int windowId, const QString &, QWaylandSurface *surface, QQuickItem *parent = 0);
 
@@ -52,6 +54,8 @@ public:
     virtual bool isInProcess() const;
 
     QRect mouseRegionBounds() const;
+
+    Qt::ScreenOrientations supportedOrientations() const;
 
 protected:
     virtual bool event(QEvent *);
@@ -86,6 +90,7 @@ private:
     bool m_mouseRegionValid:1;
     QVariant m_data;
     QRegion m_mouseRegion;
+    Qt::ScreenOrientations m_supportedOrientations;
 };
 
 #endif // LIPSTICKCOMPOSITORWINDOW_H


### PR DESCRIPTION
This information can then be used to rotate the application windows only to specific orientations.
