### PR TITLE
Don't set the size of the HomeWindow's root item - let the item handle i...

### DIFF
--- a/src/homewindow.cpp
+++ b/src/homewindow.cpp
@@ -178,8 +178,6 @@ void HomeWindow::setSource(const QUrl &source)
     if (QQuickItem *item = qobject_cast<QQuickItem *>(o)) {
         d->root = item;
 
-        d->root->setSize(d->geometry.size());
-
         if (d->isWindow())
             item->setParentItem(d->window->contentItem());
         else if (d->compositorWindow)


### PR DESCRIPTION
...ts own size
