### PR TITLE
[lipstick] Queue a window update on map/unmap/surface damage

### DIFF
--- a/src/compositor/lipstickcompositor.cpp
+++ b/src/compositor/lipstickcompositor.cpp
@@ -36,6 +36,7 @@ LipstickCompositor::LipstickCompositor()
     m_instance = this;
 
     QObject::connect(this, SIGNAL(frameSwapped()), this, SLOT(windowSwapped()));
+    QObject::connect(this, SIGNAL(beforeSynchronizing()), this, SLOT(clearUpdateRequest()));
     connect(m_displayState, SIGNAL(displayStateChanged(MeeGo::QmDisplayState::DisplayState)), this, SLOT(reactOnDisplayStateChanges(MeeGo::QmDisplayState::DisplayState)));
 
     emit HomeApplication::instance()->homeActiveChanged();
@@ -233,6 +234,19 @@ void LipstickCompositor::surfaceAboutToBeDestroyed(QWaylandSurface *surface)
     }
 }
 
+void LipstickCompositor::clearUpdateRequest()
+{
+    // Called from render thread
+    m_updateRequestPosted.store(0);
+}
+
+void LipstickCompositor::maybePostUpdateRequest()
+{
+    // Called from GUI thread
+    if (m_updateRequestPosted.testAndSetOrdered(0, 1))
+        qApp->postEvent(this, new QEvent(QEvent::User));
+}
+
 void LipstickCompositor::surfaceMapped()
 {
     QWaylandSurface *surface = qobject_cast<QWaylandSurface *>(sender());
@@ -243,14 +257,20 @@ void LipstickCompositor::surfaceMapped()
     QVariantMap properties = surface->windowProperties();
     QString category = properties.value("CATEGORY").toString();
 
-    if (surface->surfaceItem())
+    if (surface->surfaceItem()) {
+        // Always cause a repaint on surface mapped
+        maybePostUpdateRequest();
         return;
+    }
 
     // The surface was mapped for the first time
     int id = m_nextWindowId++;
     LipstickCompositorWindow *item = new LipstickCompositorWindow(id, category, surface, contentItem());
     item->setSize(surface->size());
     QObject::connect(item, SIGNAL(destroyed(QObject*)), this, SLOT(windowDestroyed()));
+
+    // Whenever the item is damaged, cause a full repaint
+    QObject::connect(item, SIGNAL(textureChanged()), this, SLOT(maybePostUpdateRequest()));
     m_totalWindowCount++;
     m_mappedSurfaces.insert(id, item);
 
@@ -344,8 +364,12 @@ void LipstickCompositor::surfaceUnmapped(QWaylandSurface *surface)
         setFullscreenSurface(0);
 
     LipstickCompositorWindow *window = static_cast<LipstickCompositorWindow *>(surface->surfaceItem());
-    if (window)
+    if (window) {
         emit windowHidden(window);
+
+        // Always schedule an update
+        maybePostUpdateRequest();
+    }
 }
 
 void LipstickCompositor::surfaceUnmapped(LipstickCompositorProcWindow *item)
@@ -379,6 +403,17 @@ void LipstickCompositor::windowRemoved(int id)
 {
     for (int ii = 0; ii < m_windowModels.count(); ++ii)
         m_windowModels.at(ii)->remItem(id);
+}
+
+bool LipstickCompositor::event(QEvent *e)
+{
+    // Update will eventually trigger a beforeSynchronizing signal,
+    // clear the m_updateRequest there (what happens after synchronizing,
+    // needs to be updated)
+    if (e->type() == QEvent::User)
+        update();
+
+    return QQuickWindow::event(e);
 }
 
 QQmlComponent *LipstickCompositor::shaderEffectComponent()

--- a/src/compositor/lipstickcompositor.h
+++ b/src/compositor/lipstickcompositor.h
@@ -101,9 +101,12 @@ signals:
     void displayOn();
 
 protected:
-     virtual void surfaceAboutToBeDestroyed(QWaylandSurface *surface);
+    virtual bool event(QEvent *);
+    virtual void surfaceAboutToBeDestroyed(QWaylandSurface *surface);
 
 private slots:
+    void clearUpdateRequest();
+    void maybePostUpdateRequest();
     void surfaceMapped();
     void surfaceUnmapped();
     void surfaceSizeChanged();
@@ -150,6 +153,7 @@ private:
     int m_topmostWindowId;
     Qt::ScreenOrientation m_screenOrientation;
     MeeGo::QmDisplayState *m_displayState;
+    QAtomicInt m_updateRequestPosted;
 };
 
 #endif // LIPSTICKCOMPOSITOR_H

--- a/tests/stubs/lipstickcompositor_stub.h
+++ b/tests/stubs/lipstickcompositor_stub.h
@@ -31,7 +31,10 @@ class LipstickCompositorStub : public StubBase {
   virtual void setDisplayOff();
   virtual LipstickCompositorProcWindow * mapProcWindow(const QString &title, const QString &category, const QRect &);
   virtual QWaylandSurface * surfaceForId(int) const;
+  virtual bool event(QEvent *);
   virtual void surfaceAboutToBeDestroyed(QWaylandSurface *surface);
+  virtual void clearUpdateRequest();
+  virtual void maybePostUpdateRequest();
   virtual void surfaceMapped();
   virtual void surfaceUnmapped();
   virtual void surfaceSizeChanged();
@@ -164,10 +167,25 @@ QWaylandSurface * LipstickCompositorStub::surfaceForId(int id) const {
   return stubReturnValue<QWaylandSurface *>("surfaceForId");
 }
 
+bool LipstickCompositorStub::event(QEvent *e) {
+  QList<ParameterBase*> params;
+  params.append( new Parameter<QEvent * >(e));
+  stubMethodEntered("event",params);
+  return stubReturnValue<QEvent *>("event");
+}
+
 void LipstickCompositorStub::surfaceAboutToBeDestroyed(QWaylandSurface *surface) {
   QList<ParameterBase*> params;
   params.append( new Parameter<QWaylandSurface * >(surface));
   stubMethodEntered("surfaceAboutToBeDestroyed",params);
+}
+
+void LipstickCompositorStub::clearUpdateRequest() {
+  stubMethodEntered("clearUpdateRequest");
+}
+
+void LipstickCompositorStub::maybePostUpdateRequest() {
+  stubMethodEntered("maybePostUpdateRequest");
 }
 
 void LipstickCompositorStub::surfaceMapped() {
@@ -310,8 +328,20 @@ QWaylandSurface * LipstickCompositor::surfaceForId(int id) const {
   return gLipstickCompositorStub->surfaceForId(id);
 }
 
+bool LipstickCompositor::event(QEvent *e) {
+    return gLipstickCompositorStub->event(e);
+}
+
 void LipstickCompositor::surfaceAboutToBeDestroyed(QWaylandSurface *surface) {
   gLipstickCompositorStub->surfaceAboutToBeDestroyed(surface);
+}
+
+void LipstickCompositor::clearUpdateRequest() {
+    gLipstickCompositorStub->clearUpdateRequest();
+}
+
+void LipstickCompositor::maybePostUpdateRequest() {
+    gLipstickCompositorStub->maybePostUpdateRequest();
 }
 
 void LipstickCompositor::surfaceMapped() {


### PR DESCRIPTION
Calling QQuickItem::update is not always enough to guarantee
QQuickWindow frame swap, which is in turn is used to trigger
frame callbacks to clients. If a client expects a callback
but due to, for example, scene graph sync/paint optimizations,
a frame swap is skipped, it might cause a deadlock in the client
until the compositor draws a frame. Thus, schedule a repaint
always.
