### PR TITLE
[lipstick] No throttling when compositor is hidden

### DIFF
--- a/src/compositor/lipstickcompositor.cpp
+++ b/src/compositor/lipstickcompositor.cpp
@@ -75,6 +75,7 @@ void LipstickCompositor::surfaceCreated(QWaylandSurface *surface)
     connect(surface, SIGNAL(windowPropertyChanged(QString,QVariant)), this, SLOT(windowPropertyChanged(QString)));
     connect(surface, SIGNAL(raiseRequested()), this, SLOT(surfaceRaised()));
     connect(surface, SIGNAL(lowerRequested()), this, SLOT(surfaceLowered()));
+    connect(surface, SIGNAL(damaged(QRect)), this, SLOT(surfaceDamaged(QRect)));
 }
 
 void LipstickCompositor::openUrl(WaylandClient *client, const QUrl &url)
@@ -176,6 +177,15 @@ void LipstickCompositor::clearKeyboardFocus()
 void LipstickCompositor::setDisplayOff()
 {
     m_displayState->set(MeeGo::QmDisplayState::Off);
+}
+
+void LipstickCompositor::surfaceDamaged(const QRect &)
+{
+    if (!isVisible()) {
+        // If the compositor is not visible, do not throttle.
+        // make it conditional to QT_WAYLAND_COMPOSITOR_NO_THROTTLE?
+        frameFinished(0);
+    }
 }
 
 void LipstickCompositor::setFullscreenSurface(QWaylandSurface *surface)

--- a/src/compositor/lipstickcompositor.h
+++ b/src/compositor/lipstickcompositor.h
@@ -113,6 +113,7 @@ private slots:
     void surfaceTitleChanged();
     void surfaceRaised();
     void surfaceLowered();
+    void surfaceDamaged(const QRect &);
     void windowSwapped();
     void windowDestroyed();
     void windowPropertyChanged(const QString &);

--- a/tests/stubs/lipstickcompositor_stub.h
+++ b/tests/stubs/lipstickcompositor_stub.h
@@ -41,6 +41,7 @@ class LipstickCompositorStub : public StubBase {
   virtual void surfaceTitleChanged();
   virtual void surfaceRaised();
   virtual void surfaceLowered();
+  virtual void surfaceDamaged(const QRect &);
   virtual void windowSwapped();
   virtual void windowDestroyed();
   virtual void windowPropertyChanged(const QString &);
@@ -212,6 +213,12 @@ void LipstickCompositorStub::surfaceLowered() {
   stubMethodEntered("surfaceLowered");
 }
 
+void LipstickCompositorStub::surfaceDamaged(const QRect &rect) {
+    QList<ParameterBase*> params;
+    params.append( new Parameter<QRect>(rect));
+    stubMethodEntered("surfaceDamaged",params);
+}
+
 void LipstickCompositorStub::windowSwapped() {
   stubMethodEntered("windowSwapped");
 }
@@ -366,6 +373,10 @@ void LipstickCompositor::surfaceRaised() {
 
 void LipstickCompositor::surfaceLowered() {
   gLipstickCompositorStub->surfaceLowered();
+}
+
+void LipstickCompositor::surfaceDamaged(const QRect &rect) {
+  gLipstickCompositorStub->surfaceDamaged(rect);
 }
 
 void LipstickCompositor::windowSwapped() {


### PR DESCRIPTION
- For power consumption, clients should not post frames
  when compositor is hidden.
- But, for reliability, compositor should not block clients
  even though it is hidden.
  
  => This commit touches the second issue. Another fix should
    be done for announcing display off for clients.
