### PR TITLE
[lipstick] Send a cancel event when the window is "lost" during touch

### DIFF
--- a/src/compositor/lipstickcompositorwindow.h
+++ b/src/compositor/lipstickcompositorwindow.h
@@ -67,6 +67,9 @@ signals:
     void delayRemoveChanged();
     void mouseRegionBoundsChanged();
 
+private slots:
+    void handleTouchCancel();
+
 private:
     friend class LipstickCompositor;
     friend class WindowPixmapItem;


### PR DESCRIPTION
If a LipstickCompositorWindow is hidden, disabled, or touch is disabled
while a touch series is happening, future touch events will not be
received by the surface and the touch point pool may never be cleared.
For this reason, generate a TouchCancel event if the window has touch
focus and gets hidden, disabled, or touch events are disabled.
