### PR TITLE
Expose HomeWindow to QML

### DIFF
--- a/plugin/lipstickplugin.cpp
+++ b/plugin/lipstickplugin.cpp
@@ -30,6 +30,7 @@
 #include <compositor/windowpixmapitem.h>
 #include <compositor/windowproperty.h>
 #include <lipstickapi.h>
+#include <homewindow.h>
 
 static QObject *lipstickApi_callback(QQmlEngine *e, QJSEngine *)
 {
@@ -49,6 +50,7 @@ void LipstickPlugin::registerTypes(const char *uri)
     qmlRegisterType<NotificationListModel>("org.nemomobile.lipstick", 0, 1, "NotificationListModel");
     qmlRegisterType<LipstickNotification>("org.nemomobile.lipstick", 0, 1, "Notification");
     qmlRegisterType<LauncherItem>("org.nemomobile.lipstick", 0, 1, "LauncherItem");
+    qmlRegisterType<HomeWindow>("org.nemomobile.lipstick", 0, 1, "HomeWindow");
     qmlRegisterUncreatableType<NotificationPreviewPresenter>("org.nemomobile.lipstick", 0, 1, "NotificationPreviewPresenter", "This type is initialized by HomeApplication");
     qmlRegisterUncreatableType<VolumeControl>("org.nemomobile.lipstick", 0, 1, "VolumeControl", "This type is initialized by HomeApplication");
     qmlRegisterUncreatableType<USBModeSelector>("org.nemomobile.lipstick", 0, 1, "USBModeSelector", "This type is initialized by HomeApplication");

--- a/src/homewindow.cpp
+++ b/src/homewindow.cpp
@@ -113,6 +113,11 @@ bool HomeWindow::isVisible() const
     return d->isVisible;
 }
 
+void HomeWindow::setVisible(bool v)
+{
+    v ? show() : hide();
+}
+
 void HomeWindow::show()
 {
     if (d->isVisible)
@@ -164,6 +169,21 @@ void HomeWindow::showFullScreen()
 QQuickItem *HomeWindow::rootObject() const
 {
     return d->root;
+}
+
+void HomeWindow::setRootObject(QQuickItem *i)
+{
+    if (i == d->root)
+        return;
+
+    delete d->root;
+    d->root = i;
+    if (i) {
+        if (d->isWindow())
+            i->setParentItem(d->window->contentItem());
+        else if (d->compositorWindow)
+            i->setParentItem(d->compositorWindow);
+    }
 }
 
 void HomeWindow::setSource(const QUrl &source)

--- a/src/homewindow.h
+++ b/src/homewindow.h
@@ -28,16 +28,21 @@ class HomeWindowPrivate;
 class LIPSTICK_EXPORT HomeWindow : public QObject
 {
     Q_OBJECT
+    Q_PROPERTY(QString category READ category WRITE setCategory)
+    Q_PROPERTY(bool visible READ isVisible WRITE setVisible)
+    Q_PROPERTY(QQuickItem *rootObject READ rootObject WRITE setRootObject)
 public:
     HomeWindow();
     ~HomeWindow();
 
     bool isVisible() const;
+    void setVisible(bool v);
     void show();
     void hide();
     void showFullScreen();
 
     QQuickItem *rootObject() const;
+    void setRootObject(QQuickItem *i);
     void setSource(const QUrl &);
     void setWindowTitle(const QString &);
     bool hasErrors() const;

--- a/tests/stubs/homewindow.cpp
+++ b/tests/stubs/homewindow.cpp
@@ -50,6 +50,11 @@ bool HomeWindow::isVisible() const
     return d->isVisible;
 }
 
+void HomeWindow::setVisible(bool v)
+{
+    v ? show() : hide();
+}
+
 void HomeWindow::show()
 {
     d->show();
@@ -71,6 +76,11 @@ void HomeWindow::showFullScreen()
 QQuickItem *HomeWindow::rootObject() const
 {
     return d->rootObject();
+}
+
+void HomeWindow::setRootObject(QQuickItem *)
+{
+
 }
 
 void HomeWindow::setSource(const QUrl &url)

--- a/tests/ut_notificationpreviewpresenter/ut_notificationpreviewpresenter.cpp
+++ b/tests/ut_notificationpreviewpresenter/ut_notificationpreviewpresenter.cpp
@@ -66,6 +66,21 @@ bool HomeWindow::isVisible() const
     return homeWindowVisible[const_cast<HomeWindow *>(this)];
 }
 
+void HomeWindow::setVisible(bool v)
+{
+    v ? show() : hide();
+}
+
+QQuickItem *HomeWindow::rootObject() const
+{
+    return 0;
+}
+
+void HomeWindow::setRootObject(QQuickItem *)
+{
+
+}
+
 QHash<HomeWindow *, QVariantMap> homeWindowContextProperties;
 void HomeWindow::setContextProperty(const QString &key, const QVariant &value)
 {
@@ -81,7 +96,12 @@ void HomeWindow::setGeometry(const QRect &)
 {
 }
 
-QHash<HomeWindow *, QString> homeWindowCategories;
+QHash<const HomeWindow *, QString> homeWindowCategories;
+
+QString HomeWindow::category() const
+{
+    return homeWindowCategories[this];
+}
 
 void HomeWindow::setCategory(const QString &category)
 {

--- a/tests/ut_usbmodeselector/ut_usbmodeselector.cpp
+++ b/tests/ut_usbmodeselector/ut_usbmodeselector.cpp
@@ -39,7 +39,12 @@ void HomeWindow::setSource(const QUrl &)
     homeWindows.append(this);
 }
 
-QHash<HomeWindow *, QString> homeWindowCategory;
+QHash<const HomeWindow *, QString> homeWindowCategory;
+QString HomeWindow::category() const
+{
+    return homeWindowCategory[this];
+}
+
 void HomeWindow::setCategory(const QString &category)
 {
     homeWindowCategory[this] = category;
@@ -65,6 +70,21 @@ void HomeWindow::hide()
 bool HomeWindow::isVisible() const
 {
     return homeWindowVisible[const_cast<HomeWindow *>(this)];
+}
+
+void HomeWindow::setVisible(bool v)
+{
+    v ? show() : hide();
+}
+
+QQuickItem *HomeWindow::rootObject() const
+{
+    return 0;
+}
+
+void HomeWindow::setRootObject(QQuickItem *)
+{
+
 }
 
 QHash<HomeWindow *, QVariantMap> homeWindowContextProperties;


### PR DESCRIPTION
This allows to create an HomeWindow in a qml file and assign to it
a category and a child QQuickItem.

This is needed for https://github.com/nemomobile/lipstick-colorful-home/pull/27
