### PR TITLE
Create the mainwindow when setting the qml path, if needed

### DIFF
--- a/src/homeapplication.cpp
+++ b/src/homeapplication.cpp
@@ -207,15 +207,17 @@ void HomeApplication::setQmlPath(const QString &path)
 {
     _qmlPath = path;
 
-    if (_mainWindowInstance) {
+    if (_mainWindowInstance)
         _mainWindowInstance->setSource(path);
-        if (_mainWindowInstance->hasErrors()) {
-            qWarning() << "HomeApplication: Errors while loading" << path;
-            qWarning() << _mainWindowInstance->errors();
-        } else {
-            _mainWindowInstance->showFullScreen();
-            connect(LipstickCompositor::instance(), SIGNAL(frameSwapped()), this, SLOT(sendHomeReadySignalIfNotAlreadySent()));
-        }
+    else
+        mainWindowInstance();
+
+    if (_mainWindowInstance->hasErrors()) {
+        qWarning() << "HomeApplication: Errors while loading" << path;
+        qWarning() << _mainWindowInstance->errors();
+    } else {
+        _mainWindowInstance->showFullScreen();
+        connect(LipstickCompositor::instance(), SIGNAL(frameSwapped()), this, SLOT(sendHomeReadySignalIfNotAlreadySent()));
     }
 }
 


### PR DESCRIPTION
This fixes a regression introduced by bc5bd724372050c1dcf08b9c50ec01ce711cc484 for Nemo's lipstick-colorful-home.

mainWindowInstance() was never called anymore, so _mainWindowInstance was never created. This could also be fixed by calling that from the lipstick-colorful-home's main.cpp, but I think from an API pov having it created by lipstick is better, also because of the naming of the function, which makes it look like a simple getter.
