### PR TITLE
[notifications] Add x-nemo-display-on hint

### DIFF
--- a/src/notifications/notificationfeedbackplayer.cpp
+++ b/src/notifications/notificationfeedbackplayer.cpp
@@ -15,6 +15,10 @@
 
 #include <NgfClient>
 #include <QWaylandSurface>
+#include <QDBusMessage>
+#include <QDBusConnection>
+#include <QDBusPendingCall>
+#include <mce/dbus-names.h>
 #include "lipstickcompositor.h"
 #include "notificationmanager.h"
 #include "notificationpreviewpresenter.h"
@@ -51,13 +55,17 @@ void NotificationFeedbackPlayer::addNotification(uint id)
 {
     LipstickNotification *notification = NotificationManager::instance()->notification(id);
 
-    if (notification != 0) {
+    if (notification != 0 && !idToEventId.contains(notification) && isEnabled(notification)) {
+        // Ask mce to turn the screen on if requested
+        if (notification->hints().value(NotificationManager::HINT_DISPLAY_ON).toBool()) {
+            QDBusMessage msg = QDBusMessage::createMethodCall(MCE_SERVICE, MCE_REQUEST_PATH, MCE_REQUEST_IF, MCE_DISPLAY_ON_REQ);
+            QDBusConnection::systemBus().asyncCall(msg);
+        }
+
         // Play the feedback related to the notification if any
-        if (!idToEventId.contains(notification) && isEnabled(notification)) {
-            QString feedback = notification->hints().value(NotificationManager::HINT_FEEDBACK).toString();
-            if (!feedback.isEmpty()) {
-                idToEventId.insert(notification, ngfClient->play(feedback, QMap<QString, QVariant>()));
-            }
+        QString feedback = notification->hints().value(NotificationManager::HINT_FEEDBACK).toString();
+        if (!feedback.isEmpty()) {
+            idToEventId.insert(notification, ngfClient->play(feedback, QMap<QString, QVariant>()));
         }
     }
 }

--- a/src/notifications/notificationmanager.cpp
+++ b/src/notifications/notificationmanager.cpp
@@ -65,6 +65,7 @@ const char *NotificationManager::HINT_USER_REMOVABLE = "x-nemo-user-removable";
 const char *NotificationManager::HINT_USER_CLOSEABLE = "x-nemo-user-closeable";
 const char *NotificationManager::HINT_FEEDBACK = "x-nemo-feedback";
 const char *NotificationManager::HINT_HIDDEN = "x-nemo-hidden";
+const char *NotificationManager::HINT_DISPLAY_ON = "x-nemo-display-on";
 
 NotificationManager *NotificationManager::instance_ = 0;
 

--- a/src/notifications/notificationmanager.h
+++ b/src/notifications/notificationmanager.h
@@ -100,6 +100,9 @@ public:
     //! Nemo hint: Whether the notification is hidden.
     static const char *HINT_HIDDEN;
 
+    //! Nemo hint: Whether to turn the screen on when displaying preview
+    static const char *HINT_DISPLAY_ON;
+
     //! Notifation closing reasons used in the NotificationClosed signal
     enum NotificationClosedReason {
         //! The notification expired.

--- a/tests/ut_notificationfeedbackplayer/ut_notificationfeedbackplayer.cpp
+++ b/tests/ut_notificationfeedbackplayer/ut_notificationfeedbackplayer.cpp
@@ -32,6 +32,7 @@ const char *NotificationManager::HINT_PREVIEW_BODY = "x-nemo-preview-body";
 const char *NotificationManager::HINT_PREVIEW_SUMMARY = "x-nemo-preview-summary";
 const char *NotificationManager::HINT_FEEDBACK = "x-nemo-feedback";
 const char *NotificationManager::HINT_USER_REMOVABLE = "x-nemo-user-removable";
+const char *NotificationManager::HINT_DISPLAY_ON = "x-nemo-display-on";
 
 NotificationManager::NotificationManager(QObject *parent) : QObject(parent)
 {


### PR DESCRIPTION
When this hint is set for a notification, the display will be turned on when feedback is played.

This is currently done by commhistory-daemon for SMS notifications, but this seems like the cleaner and more generic way to solve it.
