### PR TITLE
[lipstick] Prevent selecting HighVolume volume in headphones when 20h li...

### DIFF
--- a/rpm/lipstick-qt5.spec
+++ b/rpm/lipstick-qt5.spec
@@ -9,7 +9,7 @@ Name:       lipstick-qt5
 # << macros
 
 Summary:    QML toolkit for homescreen creation
-Version:    0.17.0
+Version:    0.17.1
 Release:    1
 Group:      System/Libraries
 License:    LGPLv2.1

--- a/rpm/lipstick-qt5.yaml
+++ b/rpm/lipstick-qt5.yaml
@@ -1,6 +1,6 @@
 Name: lipstick-qt5
 Summary: QML toolkit for homescreen creation
-Version: 0.17.0
+Version: 0.17.1
 Release: 1
 Group: System/Libraries
 License: LGPLv2.1

--- a/src/src.pro
+++ b/src/src.pro
@@ -6,7 +6,7 @@ system(qdbusxml2cpp screenshotservice.xml -a screenshotserviceadaptor -c Screens
 
 TEMPLATE = lib
 TARGET = lipstick-qt5
-VERSION = 0.17.0
+VERSION = 0.17.1
 
 DEFINES += QT_DISABLE_DEPRECATED_BEFORE=0x000000
 DEFINES += LIPSTICK_BUILD_LIBRARY VERSION=\\\"$$VERSION\\\"


### PR DESCRIPTION
- Moved warning note control logic from qml side to c++ side.
- Volume is automatically set to safe level on warning note.
- User acknowledgement reset 20h interval. 
