### PR TITLE
[lipstick] Process icon additions and removals in batches to improve performance

### DIFF
--- a/src/components/launchermodel.h
+++ b/src/components/launchermodel.h
@@ -24,6 +24,7 @@
 
 class QFileSystemWatcher;
 class QSettings;
+class QTimer;
 
 class LIPSTICK_EXPORT LauncherModel : public QObjectListModel
 {
@@ -34,10 +35,14 @@ class LIPSTICK_EXPORT LauncherModel : public QObjectListModel
 
     QFileSystemWatcher *_fileSystemWatcher;
     QString _settingsPath;
+    QTimer *_handleChangedFilesTimer;
+    QStringList _changedFiles;
 
 private slots:
     void monitoredDirectoryChanged(const QString &changedPath);
     void monitoredFileChanged(const QString &changedPath);
+    void savePositions();
+    void handleChangedFiles();
 
 public:
     explicit LauncherModel(QObject *parent = 0);
@@ -46,9 +51,6 @@ public:
     QStringList directories() const;
     void setDirectories(QStringList);
 
-public slots:
-    void savePositions();
-
 signals:
     void directoriesChanged();
 
@@ -56,7 +58,6 @@ private:
     void reorderItems(const QMap<int, LauncherItem *> &itemsWithPositions);
     void loadPositions();
     LauncherItem *itemInModel(const QString &path);
-    void addItemIfValid(const QString &path, QMap<int, LauncherItem *> &itemsWithPositions, QSettings &launcherSettings, QSettings &globalSettings);
 };
 
 #endif // LAUNCHERMODEL_H

--- a/src/utilities/qobjectlistmodel.h
+++ b/src/utilities/qobjectlistmodel.h
@@ -40,8 +40,10 @@ public:
 
     void insertItem(int index, QObject *item);
     void addItem(QObject *item);
+    void addItems(const QList<QObject *> &items);
     void removeItem(QObject *item);
     void removeItem(int index);
+    void removeItems(const QList<QObject *> &items);
     Q_INVOKABLE QObject* get(int index);
     int indexOf(QObject *obj) const;
 


### PR DESCRIPTION
Currently adding a .desktop file in /usr/share/applications causes that file to be processed and added to the model immediately. Likewise, removing a file causes it to be removed from the model immediately. Unfortunately the QML GridView, for example, isn't very efficient at handling additions and especially not removals. Removing multiple items at the same time one by one takes a lot of time: removing 400 .desktop files at once will cause the UI to freeze for over 30 seconds on a moderately quick system. To work around this, this patch does additions and removals in batches if no files have changed during the last half a second. When doing so, it also resets the model completely if more than one item has changed, instead of changing the model one by one (causing the GridView, for example, to relayout all the items).

For 400 items this shaves off about a second or two from the addition time and about 27 seconds from the removal time.
