### PR TITLE
[notifications] Allow clients to override category hints

### DIFF
--- a/src/notifications/notificationmanager.cpp
+++ b/src/notifications/notificationmanager.cpp
@@ -260,7 +260,8 @@ void NotificationManager::applyCategoryDefinition(QVariantHash &hints)
     QString category = hints.value(HINT_CATEGORY).toString();
     if (!category.isEmpty()) {
         foreach (const QString &key, categoryDefinitionStore->allKeys(category)) {
-            hints.insert(key, categoryDefinitionStore->value(category, key));
+            if (!hints.contains(key))
+                hints.insert(key, categoryDefinitionStore->value(category, key));
         }
     }
 }


### PR DESCRIPTION
Hints specified by clients will override those defined by the category, to allow clients to selectively customize their notifications.
