### PR TITLE
[lipstick] Connect notify signal for window title changed

### DIFF
--- a/src/compositor/lipstickcompositorwindow.cpp
+++ b/src/compositor/lipstickcompositorwindow.cpp
@@ -34,6 +34,9 @@ LipstickCompositorWindow::LipstickCompositorWindow(int windowId, const QString &
     connect(this, SIGNAL(visibleChanged()), SLOT(handleTouchCancel()));
     connect(this, SIGNAL(enabledChanged()), SLOT(handleTouchCancel()));
     connect(this, SIGNAL(touchEventsEnabledChanged()), SLOT(handleTouchCancel()));
+
+    connect(this, SIGNAL(surfaceChanged()), SLOT(connectSurfaceSignals()));
+    connectSurfaceSignals();
 }
 
 QVariant LipstickCompositorWindow::userData() const
@@ -290,4 +293,16 @@ void LipstickCompositorWindow::terminateProcess(int killTimeout)
 void LipstickCompositorWindow::killProcess()
 {
     kill(processId(), SIGKILL);
+}
+
+void LipstickCompositorWindow::connectSurfaceSignals()
+{
+    foreach (const QMetaObject::Connection &connection, m_surfaceConnections) {
+        disconnect(connection);
+    }
+
+    m_surfaceConnections.clear();
+    if (surface()) {
+        m_surfaceConnections << connect(surface(), SIGNAL(titleChanged()), SIGNAL(titleChanged()));
+    }
 }

--- a/src/compositor/lipstickcompositorwindow.h
+++ b/src/compositor/lipstickcompositorwindow.h
@@ -74,6 +74,7 @@ signals:
 private slots:
     void handleTouchCancel();
     void killProcess();
+    void connectSurfaceSignals();
 
 private:
     friend class LipstickCompositor;
@@ -96,6 +97,7 @@ private:
     QVariant m_data;
     QRegion m_mouseRegion;
     QList<int> m_grabbedKeys;
+    QList<QMetaObject::Connection> m_surfaceConnections;
 };
 
 #endif // LIPSTICKCOMPOSITORWINDOW_H


### PR DESCRIPTION
When the surface's title property changes, send a notification. Also
establish a slot for handling for future surface connections.
