### PR TITLE
[lipstick] Devicelock to handle device suspended state.

### DIFF
--- a/src/devicelock/devicelock.h
+++ b/src/devicelock/devicelock.h
@@ -19,6 +19,7 @@
 #include <qmactivity.h>
 #include <qmlocks.h>
 #include <qmdisplaystate.h>
+#include <sys/time.h>
 
 class MGConfItem;
 class QTimer;
@@ -66,6 +67,7 @@ private:
     MeeGo::QmLocks *qmLocks;
     MeeGo::QmDisplayState *qmDisplayState;
     LockState deviceLockState;
+    struct timeval monoTime;
 
 #ifdef UNIT_TEST
     friend class Ut_DeviceLock;

--- a/src/src.pro
+++ b/src/src.pro
@@ -104,6 +104,8 @@ CONFIG += link_pkgconfig mobility qt warn_on depend_includepath qmake_cache targ
 CONFIG -= link_prl
 PKGCONFIG += mlite5 mce dbus-1 dbus-glib-1 libresourceqt5 ngf-qt5 qmsystem2-qt5 Qt5SystemInfo libsystemd-daemon
 
+LIBS += -lrt
+
 packagesExist(contentaction5) {
     message("Using contentaction to launch applications")
     PKGCONFIG += contentaction5

--- a/tests/ut_devicelock/ut_devicelock.pro
+++ b/tests/ut_devicelock/ut_devicelock.pro
@@ -4,6 +4,8 @@ TARGET = ut_devicelock
 INCLUDEPATH += $$DEVICELOCKSRCDIR
 QMAKE_CXXFLAGS += `pkg-config --cflags-only-I mlite5 qmsystem2-qt5`
 
+LIBS += -lrt
+
 # unit test and unit
 SOURCES += \
     ut_devicelock.cpp \


### PR DESCRIPTION
In some device QTimer doesn't trigger when device is suspended. So you need to check CLOCK_BOOTTIME for timer timeout instead since that is the only clock that updates even when suspended.
