### PR TITLE
[lipstick] Devicelock not to activate during active phonecall

### DIFF
--- a/src/devicelock/devicelock.h
+++ b/src/devicelock/devicelock.h
@@ -56,6 +56,7 @@ private slots:
     void setStateAndSetupLockTimer();
     void lock();
     void checkDisplayState(MeeGo::QmDisplayState::DisplayState state);
+    void handleCallStateChange(const QString &state, const QString &ignored);
 
 private:
     static bool runPlugin(const QStringList &args);
@@ -67,6 +68,7 @@ private:
     MeeGo::QmLocks *qmLocks;
     MeeGo::QmDisplayState *qmDisplayState;
     LockState deviceLockState;
+    bool isCallActive;
     struct timeval monoTime;
 
 #ifdef UNIT_TEST

--- a/tests/ut_devicelock/ut_devicelock.pro
+++ b/tests/ut_devicelock/ut_devicelock.pro
@@ -4,6 +4,8 @@ TARGET = ut_devicelock
 INCLUDEPATH += $$DEVICELOCKSRCDIR
 QMAKE_CXXFLAGS += `pkg-config --cflags-only-I mlite5 qmsystem2-qt5`
 
+QT += dbus
+
 LIBS += -lrt
 
 # unit test and unit


### PR DESCRIPTION
We don't want device to lock itself on long telephone calls (where proximity sensor has blanked the screen). JB#11961
