### PR TITLE
[lipstick] ShutdownScreen: Allow shutdown mode only from privileged sources

### DIFF
--- a/plugin/plugin.pro
+++ b/plugin/plugin.pro
@@ -3,7 +3,7 @@ TARGET = lipstickplugin
 VERSION = 0.1
 
 CONFIG += qt plugin link_pkgconfig
-QT += core gui qml quick compositor
+QT += core gui qml quick compositor dbus
 PKGCONFIG += qmsystem2-qt5
 
 INSTALLS = target qmldirfile

--- a/src/shutdownscreen.h
+++ b/src/shutdownscreen.h
@@ -17,13 +17,14 @@
 #define SHUTDOWNSCREEN_H
 
 #include <QObject>
+#include <QDBusContext>
 #include "lipstickglobal.h"
 #include <qmsystemstate.h>
 #include <qmthermal.h>
 
 class HomeWindow;
 
-class LIPSTICK_EXPORT ShutdownScreen : public QObject
+class LIPSTICK_EXPORT ShutdownScreen : public QObject, protected QDBusContext
 {
     Q_OBJECT
     Q_PROPERTY(bool windowVisible READ windowVisible WRITE setWindowVisible NOTIFY windowVisibleChanged)
@@ -97,6 +98,8 @@ private:
 #ifdef UNIT_TEST
     friend class Ut_ShutdownScreen;
 #endif
+
+    bool isPrivileged();
 };
 
 #endif // SHUTDOWNSCREEN_H


### PR DESCRIPTION
Shutdown mode wouldn't be nice to trigger from where ever so let's check
the caller's effective pid/gid to know we should trust them to use it
properly.

Implementation of isPrivileged is grabbed from Password Manager.

Signed-off-by: Kalle Vahlman kalle.vahlman@movial.com
