### PR TITLE
[lipstick] Make a copy of retained selection

### DIFF
--- a/src/compositor/lipstickcompositor.h
+++ b/src/compositor/lipstickcompositor.h
@@ -21,6 +21,7 @@
 #include <QQmlParserStatus>
 #include <QWaylandCompositor>
 #include <QWaylandSurfaceItem>
+#include <QPointer>
 #include <qmdisplaystate.h>
 
 class WindowModel;
@@ -165,7 +166,7 @@ private:
     MeeGo::QmDisplayState *m_displayState;
     QAtomicInt m_updateRequestPosted;
     QOrientationSensor* m_orientationSensor;
-    const QMimeData *m_retainedSelection;
+    QPointer<QMimeData> m_retainedSelection;
 };
 
 #endif // LIPSTICKCOMPOSITOR_H


### PR DESCRIPTION
The retained selection was inappropriately passing the compositor's
mimeData pointer to QClipboard, leaving the possibility for the object
to be get deleted twice.
