### PR TITLE
[lipstick] Fix devicelock to use QSettings and not GConf

### DIFF
--- a/src/devicelock/devicelock.h
+++ b/src/devicelock/devicelock.h
@@ -20,6 +20,7 @@
 #include <qmlocks.h>
 #include <qmdisplaystate.h>
 #include <sys/time.h>
+#include <QFileSystemWatcher>
 
 class MGConfItem;
 class QTimer;
@@ -57,12 +58,14 @@ private slots:
     void lock();
     void checkDisplayState(MeeGo::QmDisplayState::DisplayState state);
     void handleCallStateChange(const QString &state, const QString &ignored);
+    void readSettings();
 
 private:
     static bool runPlugin(const QStringList &args);
     void setupTimer();
 
-    MGConfItem *lockingGConfItem;
+    int lockingDelay;
+    QFileSystemWatcher watcher;
     QTimer *lockTimer;
     MeeGo::QmActivity *qmActivity;
     MeeGo::QmLocks *qmLocks;

--- a/tests/ut_devicelock/ut_devicelock.pro
+++ b/tests/ut_devicelock/ut_devicelock.pro
@@ -2,7 +2,7 @@ include(../common.pri)
 TARGET = ut_devicelock
 
 INCLUDEPATH += $$DEVICELOCKSRCDIR
-QMAKE_CXXFLAGS += `pkg-config --cflags-only-I mlite5 qmsystem2-qt5`
+QMAKE_CXXFLAGS += `pkg-config --cflags-only-I qmsystem2-qt5`
 
 QT += dbus
 
@@ -18,7 +18,6 @@ SOURCES += \
 HEADERS += \
     ut_devicelock.h \
     $$DEVICELOCKSRCDIR/devicelock.h \
-    /usr/include/mlite5/mgconfitem.h \
     /usr/include/qmsystem2-qt5/qmlocks.h \
     /usr/include/qmsystem2-qt5/qmactivity.h \
     /usr/include/qmsystem2-qt5/qmdisplaystate.h


### PR DESCRIPTION
GConf settings doesn't sync well, so if end user removes battery, then settings might not be in valid state.
This change changed devicelock to use QSettings instead of GConf, and I also fixed broken tests.

Do not merge until the depending changes in JB#8859 have landed.
