### PR TITLE
[lipstick] Use icon-launcher-screenshot instead of icon-launcher-setting...

### DIFF
--- a/tools/screenshottool/application/screenshottool.desktop
+++ b/tools/screenshottool/application/screenshottool.desktop
@@ -1,5 +1,5 @@
 [Desktop Entry]
 Type=Application
 Name=Screenshot
-Icon=icon-launcher-settings
+Icon=icon-launcher-screenshot
 Exec=screenshottool


### PR DESCRIPTION
...s for Screenshot app

This allows a different icon to be used for the screenshot tool. Requested by https://github.com/nemomobile/lipstick/pull/122#issuecomment-30131025.
