### PR TITLE
[lipstick] Only emit volume changes when the volume actually changes

### DIFF
--- a/src/volume/volumecontrol.h
+++ b/src/volume/volumecontrol.h
@@ -118,6 +118,9 @@ signals:
     //! Sent when the volume has changed.
     void volumeChanged();
 
+    //! Sent when a volume key was pressed or a key repeat occurred.
+    void volumeKeyPressed();
+
     //! Sent when the maximum volume has changed.
     void maximumVolumeChanged();
 

--- a/tests/ut_volumecontrol/ut_volumecontrol.h
+++ b/tests/ut_volumecontrol/ut_volumecontrol.h
@@ -41,6 +41,7 @@ private slots:
     void testHwKeyEventWhenKeyReleaseIsInProgress();
     void testAcquireKeys();
     void testReleaseKeys();
+    void testMaximumVolume();
 
 private:
     VolumeControl *volumeControl;


### PR DESCRIPTION
- don't emit volume change signals unless the volume actually changes
- do emit window visibility change signals even if the expected window visibility didn't change so that the UI will know that it's still expected to show the window
