### PR TITLE
[lipstick] Rework volume key repeat handling to match current Wayland behavior

### DIFF
--- a/src/volume/volumecontrol.cpp
+++ b/src/volume/volumecontrol.cpp
@@ -43,12 +43,9 @@ VolumeControl::VolumeControl(QObject *parent) :
     connect(hwKeyResource, SIGNAL(lostResources()), this, SLOT(hwKeyResourceLost()));
 
     // Set up key repeat: initial delay and per-repeat delay
-    keyReleaseTimer.setSingleShot(true);
-    keyReleaseTimer.setInterval(100);
     keyRepeatDelayTimer.setSingleShot(true);
     keyRepeatDelayTimer.setInterval(600);
     keyRepeatTimer.setInterval(75);
-    connect(&keyReleaseTimer, SIGNAL(timeout()), this, SLOT(stopKeyRepeat()));
     connect(&keyRepeatDelayTimer, SIGNAL(timeout()), &keyRepeatTimer, SLOT(start()));
     connect(&keyRepeatTimer, SIGNAL(timeout()), this, SLOT(changeVolume()));
 
@@ -243,8 +240,8 @@ bool VolumeControl::eventFilter(QObject *, QEvent *event)
                     changeVolume();
                 }
             } else {
-                // Key up: stop any key repeating in progress
-                keyReleaseTimer.start();
+                // Key up: stop any key repeating in progress and the repeat delay timer
+                stopKeyRepeat();
             }
             return true;
         }

--- a/src/volume/volumecontrol.h
+++ b/src/volume/volumecontrol.h
@@ -164,9 +164,6 @@ private slots:
     //! Changes the current volume by the amount set in volumeChange
     void changeVolume();
 
-    //! Stops any key repeat in progress
-    void stopKeyRepeat();
-
     //! Used to capture safe volume level and reset it to safe when needed.
     void handleHighVolume(int safeLevel);
 
@@ -174,6 +171,9 @@ private slots:
     void handleLongListeningTime(int listeningTime);
 
 private:
+    //! Stops any key repeat in progress
+    void stopKeyRepeat();
+
     //! The volume control window
     HomeWindow *window;
 
@@ -194,9 +194,6 @@ private:
 
     //! Volume change executed when calling changeVolume()
     int volumeChange;
-
-    //! Timer for differentiating between a key release and a repress
-    QTimer keyReleaseTimer;
 
     //! Timer for the key repeat delay
     QTimer keyRepeatDelayTimer;

--- a/tests/ut_volumecontrol/ut_volumecontrol.cpp
+++ b/tests/ut_volumecontrol/ut_volumecontrol.cpp
@@ -138,12 +138,9 @@ void Ut_VolumeControl::testConnections()
 
 void Ut_VolumeControl::testKeyRepeatSetup()
 {
-    QCOMPARE(volumeControl->keyReleaseTimer.interval(), 100);
-    QCOMPARE(volumeControl->keyReleaseTimer.isSingleShot(), true);
     QCOMPARE(volumeControl->keyRepeatDelayTimer.interval(), 600);
     QCOMPARE(volumeControl->keyRepeatDelayTimer.isSingleShot(), true);
     QCOMPARE(volumeControl->keyRepeatTimer.interval(), 75);
-    QCOMPARE(disconnect(&volumeControl->keyReleaseTimer, SIGNAL(timeout()), volumeControl, SLOT(stopKeyRepeat())), true);
     QCOMPARE(disconnect(&volumeControl->keyRepeatDelayTimer, SIGNAL(timeout()), &volumeControl->keyRepeatTimer, SLOT(start())), true);
     QCOMPARE(disconnect(&volumeControl->keyRepeatTimer, SIGNAL(timeout()), volumeControl, SLOT(changeVolume())), true);
 }
@@ -261,21 +258,15 @@ void Ut_VolumeControl::testHwKeyEventWhenKeyReleaseIsInProgress()
     volumeControl->keyRepeatTimer.start();
     disconnect(this, SIGNAL(timeout()), &volumeControl->keyRepeatDelayTimer, SIGNAL(timeout()));
 
-    // Key release should not stop the repeat timer but start the release timer
+    // Key release should stop the repeat timer and the delay timer
     QKeyEvent event(QEvent::KeyRelease, Qt::Key_VolumeDown, 0);
     volumeControl->eventFilter(0, &event);
-    QCOMPARE(qTimerStartCounts.value(&volumeControl->keyReleaseTimer), 1);
     QCOMPARE(qTimerStartCounts.value(&volumeControl->keyRepeatDelayTimer), 0);
     QCOMPARE(qTimerStartCounts.value(&volumeControl->keyRepeatTimer), 1);
-    QCOMPARE(qTimerStopCounts.value(&volumeControl->keyRepeatTimer), 0);
-    QCOMPARE(volumeChangedSpy.count(), 0);
-    QCOMPARE(volumeKeyPressedSpy.count(), 0);
-
-    // Timeout in the release timer should stop the repeat
-    connect(this, SIGNAL(timeout()), &volumeControl->keyReleaseTimer, SIGNAL(timeout()));
-    emit timeout();
     QCOMPARE(qTimerStopCounts.value(&volumeControl->keyRepeatDelayTimer), 1);
     QCOMPARE(qTimerStopCounts.value(&volumeControl->keyRepeatTimer), 1);
+    QCOMPARE(volumeChangedSpy.count(), 0);
+    QCOMPARE(volumeKeyPressedSpy.count(), 0);
 }
 
 void Ut_VolumeControl::testAcquireKeys()


### PR DESCRIPTION
Until https://codereview.qt-project.org/#change,73873 gets in, Lipstick volume key repeating is broken with Wayland. This patch makes Lipstick work with the current key handling where there's only one key press event when the volume key is pressed and one key up when it gets released.
