### PR TITLE
Add USB cellular/data connection sharing Contributes: JB#13598

### DIFF
--- a/rpm/lipstick-qt5.spec
+++ b/rpm/lipstick-qt5.spec
@@ -36,7 +36,7 @@ BuildRequires:  pkgconfig(dbus-1)
 BuildRequires:  pkgconfig(dbus-glib-1)
 BuildRequires:  pkgconfig(libresourceqt5)
 BuildRequires:  pkgconfig(ngf-qt5)
-BuildRequires:  pkgconfig(qmsystem2-qt5) >= 1.4.11
+BuildRequires:  pkgconfig(qmsystem2-qt5) >= 1.4.15
 BuildRequires:  pkgconfig(contextkit-statefs) >= 0.2.7
 BuildRequires:  pkgconfig(systemd)
 BuildRequires:  qt5-qttools-linguist

--- a/src/usbmodeselector.cpp
+++ b/src/usbmodeselector.cpp
@@ -109,6 +109,7 @@ void USBModeSelector::applyUSBMode(MeeGo::QmUSBMode::Mode mode)
     case MeeGo::QmUSBMode::Developer:
     case MeeGo::QmUSBMode::Adb:
     case MeeGo::QmUSBMode::Diag:
+    case MeeGo::QmUSBMode::ConnectionSharing:
         // Hide the mode selection dialog and show a mode notification
         setWindowVisible(false);
         showNotification(mode);
@@ -158,6 +159,10 @@ void USBModeSelector::showNotification(MeeGo::QmUSBMode::Mode mode)
         category = "device.removed";
         //% "USB cable disconnected"
         body = qtTrId("qtn_usb_disconnected");
+        break;
+    case MeeGo::QmUSBMode::ConnectionSharing:
+        //% "USB tethering in use"
+        body = qtTrId("qtn_usb_connection_sharing_active");
         break;
     default:
         return;

--- a/tests/ut_usbmodeselector/ut_usbmodeselector.cpp
+++ b/tests/ut_usbmodeselector/ut_usbmodeselector.cpp
@@ -158,6 +158,7 @@ void Ut_USBModeSelector::testHideDialog_data()
     QTest::newRow("Developer") << MeeGo::QmUSBMode::Developer;
     QTest::newRow("Adb") << MeeGo::QmUSBMode::Adb;
     QTest::newRow("Diag") << MeeGo::QmUSBMode::Diag;
+    QTest::newRow("Cellular connection sharing") << MeeGo::QmUSBMode::ConnectionSharing;
 }
 
 void Ut_USBModeSelector::testHideDialog()
@@ -184,6 +185,7 @@ void Ut_USBModeSelector::testUSBNotifications_data()
     QTest::newRow("MTP") << MeeGo::QmUSBMode::MTP << "device.added" << qtTrId("qtn_usb_mtp_active");
     QTest::newRow("Adb") << MeeGo::QmUSBMode::Adb << "device.added" << qtTrId("qtn_usb_adb_active");
     QTest::newRow("Diag") << MeeGo::QmUSBMode::Diag << "device.added" << qtTrId("qtn_usb_diag_active");
+    QTest::newRow("Cellular connection sharing") << MeeGo::QmUSBMode::ConnectionSharing << "device.added" << qtTrId("qtn_usb_connection_sharing_active");
 }
 
 void Ut_USBModeSelector::testUSBNotifications()


### PR DESCRIPTION
Add USB cellular/data connection sharing Contributes: JB#13598

Spec file might need a version bump still. Updated dependencies though. 
UI is ok, but will need some extras later.

Signed-off-by: Philippe De Swert philippe.deswert@jollamobile.com
