### PR TITLE
Revert "[lipstick] Queue a window update on map/unmap/surface damage"

### DIFF
--- a/src/compositor/lipstickcompositor.h
+++ b/src/compositor/lipstickcompositor.h
@@ -119,12 +119,9 @@ signals:
     void displayAboutToBeOn();
 
 protected:
-    virtual bool event(QEvent *);
     virtual void surfaceAboutToBeDestroyed(QWaylandSurface *surface);
 
 private slots:
-    void clearUpdateRequest();
-    void maybePostUpdateRequest();
     void surfaceMapped();
     void surfaceUnmapped();
     void surfaceSizeChanged();
@@ -176,7 +173,6 @@ private:
     Qt::ScreenOrientation m_screenOrientation;
     Qt::ScreenOrientation m_sensorOrientation;
     MeeGo::QmDisplayState *m_displayState;
-    QAtomicInt m_updateRequestPosted;
     QOrientationSensor* m_orientationSensor;
     QPointer<QMimeData> m_retainedSelection;
     QSettings m_compositorSettings;

--- a/tests/stubs/lipstickcompositor_stub.h
+++ b/tests/stubs/lipstickcompositor_stub.h
@@ -33,10 +33,7 @@ class LipstickCompositorStub : public StubBase {
   virtual void setDisplayOff();
   virtual LipstickCompositorProcWindow * mapProcWindow(const QString &title, const QString &category, const QRect &);
   virtual QWaylandSurface * surfaceForId(int) const;
-  virtual bool event(QEvent *);
   virtual void surfaceAboutToBeDestroyed(QWaylandSurface *surface);
-  virtual void clearUpdateRequest();
-  virtual void maybePostUpdateRequest();
   virtual void surfaceMapped();
   virtual void surfaceUnmapped();
   virtual void surfaceSizeChanged();
@@ -183,25 +180,10 @@ QWaylandSurface * LipstickCompositorStub::surfaceForId(int id) const {
   return stubReturnValue<QWaylandSurface *>("surfaceForId");
 }
 
-bool LipstickCompositorStub::event(QEvent *e) {
-  QList<ParameterBase*> params;
-  params.append( new Parameter<QEvent * >(e));
-  stubMethodEntered("event",params);
-  return stubReturnValue<QEvent *>("event");
-}
-
 void LipstickCompositorStub::surfaceAboutToBeDestroyed(QWaylandSurface *surface) {
   QList<ParameterBase*> params;
   params.append( new Parameter<QWaylandSurface * >(surface));
   stubMethodEntered("surfaceAboutToBeDestroyed",params);
-}
-
-void LipstickCompositorStub::clearUpdateRequest() {
-  stubMethodEntered("clearUpdateRequest");
-}
-
-void LipstickCompositorStub::maybePostUpdateRequest() {
-  stubMethodEntered("maybePostUpdateRequest");
 }
 
 void LipstickCompositorStub::surfaceMapped() {
@@ -365,20 +347,8 @@ QWaylandSurface * LipstickCompositor::surfaceForId(int id) const {
   return gLipstickCompositorStub->surfaceForId(id);
 }
 
-bool LipstickCompositor::event(QEvent *e) {
-    return gLipstickCompositorStub->event(e);
-}
-
 void LipstickCompositor::surfaceAboutToBeDestroyed(QWaylandSurface *surface) {
   gLipstickCompositorStub->surfaceAboutToBeDestroyed(surface);
-}
-
-void LipstickCompositor::clearUpdateRequest() {
-    gLipstickCompositorStub->clearUpdateRequest();
-}
-
-void LipstickCompositor::maybePostUpdateRequest() {
-    gLipstickCompositorStub->maybePostUpdateRequest();
 }
 
 void LipstickCompositor::surfaceMapped() {


### PR DESCRIPTION
Removing invalid workaround for the case where scenegraph sync caused by new client buffer does not lead to render (and frame swap), leaving wayland clients waiting for frame event. Fixed properly in qtwayland.

This reverts commit 7c127ccdb6a4101d499e3aef48a48f8c12783297.

Conflicts:

```
src/compositor/lipstickcompositor.h
```
