### PR TITLE
[lipstick] Remove event eater when display becomes undimmed.

### DIFF
--- a/src/screenlock/screenlock.h
+++ b/src/screenlock/screenlock.h
@@ -108,6 +108,9 @@ private slots:
     //! Hides the event eater window.
     void hideEventEater();
 
+    //! Clear event eater if display is no longer dimmed
+    void handleDisplayStateChange(int displayState);
+
 signals:
     //! Emitted when the screen lock state changes
     void screenIsLocked(bool locked);

--- a/tests/stubs/screenlock_stub.h
+++ b/tests/stubs/screenlock_stub.h
@@ -40,6 +40,7 @@ class ScreenLockStub : public StubBase {
   virtual void hideScreenLockAndEventEater();
   virtual void showEventEater();
   virtual void hideEventEater();
+  virtual void handleDisplayStateChange(int);
   virtual bool isScreenLocked();
   virtual bool eventFilter(QObject *, QEvent *event);
 }; 
@@ -130,6 +131,12 @@ void ScreenLockStub::hideEventEater() {
   stubMethodEntered("hideEventEater");
 }
 
+void ScreenLockStub::handleDisplayStateChange(int displayState){
+    QList<ParameterBase*> params;
+    params.append( new Parameter<int >(displayState));
+    stubMethodEntered("handleDisplayStateChange", params);
+}
+
 bool ScreenLockStub::isScreenLocked() {
   stubMethodEntered("isScreenLocked");
   return stubReturnValue<bool>("isScreenLocked");
@@ -209,6 +216,10 @@ void ScreenLock::showEventEater() {
 
 void ScreenLock::hideEventEater() {
   gScreenLockStub->hideEventEater();
+}
+
+void ScreenLock::handleDisplayStateChange(int displayState) {
+  gScreenLockStub->handleDisplayStateChange(displayState);
 }
 
 bool ScreenLock::isScreenLocked() const {

--- a/tests/ut_screenlock/ut_screenlock.pro
+++ b/tests/ut_screenlock/ut_screenlock.pro
@@ -3,6 +3,8 @@ TARGET = ut_screenlock
 QT += dbus qml quick
 CONFIG += link_pkgconfig
 
+PKGCONFIG += qmsystem2-qt5
+
 INCLUDEPATH += $$SCREENLOCKSRCDIR $$UTILITYSRCDIR $$SRCDIR/xtools
 
 SOURCES += ut_screenlock.cpp \


### PR DESCRIPTION
Event eater is needed only when display is dimmed.
