### PR TITLE
[lipstick] Fix for Device lock is sometimes activated when using device

### DIFF
--- a/src/devicelock/devicelock.cpp
+++ b/src/devicelock/devicelock.cpp
@@ -119,7 +119,6 @@ void DeviceLock::setStateAndSetupLockTimer()
 void DeviceLock::checkDisplayState(MeeGo::QmDisplayState::DisplayState state)
 {
     if (lockingDelay == 0 && state == MeeGo::QmDisplayState::DisplayState::Off
-            && qmLocks->getState(MeeGo::QmLocks::TouchAndKeyboard) == MeeGo::QmLocks::Locked
             && !isCallActive) {
         // Immediate locking enabled and the display is off and not in call: lock
         setState(Locked);
@@ -131,6 +130,7 @@ void DeviceLock::checkDisplayState(MeeGo::QmDisplayState::DisplayState state)
         if (lockingDelay*60 < tv_diff_in_s(&compareTime, &monoTime)) {
             setState(Locked);
         }
+        setupLockTimer();
     }
 }
 


### PR DESCRIPTION
Recent chages in mce stopped sending qmLock signals while suspended, which
breaks the logic in devicelock handling. In some cases like on android
games and videoplayer triggered qmActivity inactive signal which
triggered devicelock timer to start. And then display ON signal came the
timer was not resetted because qmActivity and qmLocks mce signaling was
changed. Which triggered devicelock code to be shown when swiping away
from long usage applications.

With this change we add handling to check possible lockTimer reset on
display ON signal. And we no longer query for qmLocks state when
lockingDelay == 0.
