### PR TITLE
[lipstick] Allow the UI part to define the minimum notification priority to play feedbacks for

### DIFF
--- a/plugin/lipstickplugin.cpp
+++ b/plugin/lipstickplugin.cpp
@@ -20,6 +20,7 @@
 #include <components/launcheritem.h>
 #include <components/launchermodel.h>
 #include <notifications/notificationpreviewpresenter.h>
+#include <notifications/notificationfeedbackplayer.h>
 #include <notifications/notificationlistmodel.h>
 #include <notifications/lipsticknotification.h>
 #include <volume/volumecontrol.h>
@@ -50,6 +51,7 @@ void LipstickPlugin::registerTypes(const char *uri)
     qmlRegisterType<LipstickNotification>("org.nemomobile.lipstick", 0, 1, "Notification");
     qmlRegisterType<LauncherItem>("org.nemomobile.lipstick", 0, 1, "LauncherItem");
     qmlRegisterUncreatableType<NotificationPreviewPresenter>("org.nemomobile.lipstick", 0, 1, "NotificationPreviewPresenter", "This type is initialized by HomeApplication");
+    qmlRegisterUncreatableType<NotificationFeedbackPlayer>("org.nemomobile.lipstick", 0, 1, "NotificationFeedbackPlayer", "This type is initialized by HomeApplication");
     qmlRegisterUncreatableType<VolumeControl>("org.nemomobile.lipstick", 0, 1, "VolumeControl", "This type is initialized by HomeApplication");
     qmlRegisterUncreatableType<USBModeSelector>("org.nemomobile.lipstick", 0, 1, "USBModeSelector", "This type is initialized by HomeApplication");
     qmlRegisterUncreatableType<ShutdownScreen>("org.nemomobile.lipstick", 0, 1, "ShutdownScreen", "This type is initialized by HomeApplication");

--- a/src/homeapplication.cpp
+++ b/src/homeapplication.cpp
@@ -26,7 +26,6 @@
 
 #include "notifications/notificationmanager.h"
 #include "notifications/notificationpreviewpresenter.h"
-#include "notifications/notificationfeedbackplayer.h"
 #include "notifications/batterynotifier.h"
 #include "notifications/diskspacenotifier.h"
 #include "screenlock/screenlock.h"
@@ -84,7 +83,7 @@ HomeApplication::HomeApplication(int &argc, char **argv, const QString &qmlPath)
 
     // Initialize the notification manager
     NotificationManager::instance();
-    new NotificationFeedbackPlayer(new NotificationPreviewPresenter(this));
+    new NotificationPreviewPresenter(this);
 
     // Create screen lock logic - not parented to "this" since destruction happens too late in that case
     screenLock = new ScreenLock;

--- a/src/notifications/notificationfeedbackplayer.h
+++ b/src/notifications/notificationfeedbackplayer.h
@@ -16,11 +16,11 @@
 #ifndef NOTIFICATIONFEEDBACKPLAYER_H
 #define NOTIFICATIONFEEDBACKPLAYER_H
 
+#include "lipstickglobal.h"
 #include <QObject>
 #include <QHash>
 
 class LipstickNotification;
-class NotificationPreviewPresenter;
 namespace Ngf {
     class Client;
 }
@@ -30,13 +30,32 @@ namespace Ngf {
  *
  * \brief Plays non-graphical feedback for notifications.
  */
-class NotificationFeedbackPlayer : public QObject
+class LIPSTICK_EXPORT NotificationFeedbackPlayer : public QObject
 {
     Q_OBJECT
+    Q_PROPERTY(int minimumPriority READ minimumPriority WRITE setMinimumPriority NOTIFY minimumPriorityChanged)
 
 public:
-    explicit NotificationFeedbackPlayer(NotificationPreviewPresenter *notificationPreviewPresenter = 0);
-    
+    explicit NotificationFeedbackPlayer(QObject *parent = 0);
+
+    /*!
+     * Returns the minimum priority of notifications for which a feedback should be played
+     *
+     * \return the minimum priority of notifications for which a feedback should be played
+     */
+    int minimumPriority() const;
+
+    /*!
+     * Sets the minimum priority of notifications for which a feedback should be played
+     *
+     * \param minimumPriority the minimum priority of notifications for which a feedback should be played
+     */
+    void setMinimumPriority(int minimumPriority);
+
+signals:
+    //! Emitted when the minimum priority of notifications for which a feedback should be played has changed
+    void minimumPriorityChanged();
+
 private slots:
     //! Initializes the feedback player
     void init();
@@ -57,7 +76,7 @@ private slots:
 
 private:
     //! Check whether feedbacks should be enabled for the given notification
-    static bool isEnabled(LipstickNotification *notification);
+    bool isEnabled(LipstickNotification *notification);
 
     //! Non-graphical feedback player
     Ngf::Client *ngfClient;
@@ -65,8 +84,8 @@ private:
     //! A mapping between notification IDs and NGF play IDs.
     QHash<LipstickNotification *, uint> idToEventId;
 
-    //! The notification preview presenter this feedback player is synced to
-    NotificationPreviewPresenter *notificationPreviewPresenter;
+    //! The minimum priority of notifications for which a feedback should be played
+    int minimumPriority_;
 
 #ifdef UNIT_TEST
     friend class Ut_NotificationFeedbackPlayer;

--- a/src/notifications/notificationpreviewpresenter.h
+++ b/src/notifications/notificationpreviewpresenter.h
@@ -21,6 +21,7 @@
 
 class HomeWindow;
 class LipstickNotification;
+class NotificationFeedbackPlayer;
 
 namespace MeeGo {
 class QmLocks;
@@ -91,10 +92,10 @@ private slots:
      */
     void removeNotification(uint id, bool onlyFromQueue = false);
 
-private:
     //! Creates the notification window if it has not been created yet.
     void createWindowIfNecessary();
 
+private:
     //! Checks whether the given notification has a preview body and a preview summary.
     bool notificationShouldBeShown(LipstickNotification *notification);
 
@@ -109,6 +110,9 @@ private:
 
     //! Notification currently being shown
     LipstickNotification *currentNotification;
+
+    //! Player for notification feedbacks
+    NotificationFeedbackPlayer *notificationFeedbackPlayer;
 
     //! For getting information about the touch screen lock state
     MeeGo::QmLocks *locks;

--- a/tests/stubs/notificationfeedbackplayer_stub.h
+++ b/tests/stubs/notificationfeedbackplayer_stub.h
@@ -1,0 +1,99 @@
+/***************************************************************************
+**
+** Copyright (C) 2012-2014 Jolla Ltd.
+** Contact: Robin Burchell <robin.burchell@jollamobile.com>
+**
+** This file is part of lipstick.
+**
+** This library is free software; you can redistribute it and/or
+** modify it under the terms of the GNU Lesser General Public
+** License version 2.1 as published by the Free Software Foundation
+** and appearing in the file LICENSE.LGPL included in the packaging
+** of this file.
+**
+****************************************************************************/
+#ifndef NOTIFICATIONFEEDBACKPLAYER_STUB
+#define NOTIFICATIONFEEDBACKPLAYER_STUB
+
+#include "notificationfeedbackplayer.h"
+#include <stubbase.h>
+
+
+// 1. DECLARE STUB
+// FIXME - stubgen is not yet finished
+class NotificationFeedbackPlayerStub : public StubBase {
+  public:
+  virtual void NotificationFeedbackPlayerConstructor(QObject *parent);
+  virtual int minimumPriority() const;
+  virtual void setMinimumPriority(int minimumPriority);
+  virtual void init();
+  virtual void addNotification(uint id);
+  virtual void removeNotification(uint id);
+}; 
+
+// 2. IMPLEMENT STUB
+void NotificationFeedbackPlayerStub::NotificationFeedbackPlayerConstructor(QObject *parent) {
+  Q_UNUSED(parent);
+
+}
+int NotificationFeedbackPlayerStub::minimumPriority() const {
+  stubMethodEntered("minimumPriority");
+  return stubReturnValue<int>("minimumPriority");
+}
+
+void NotificationFeedbackPlayerStub::setMinimumPriority(int minimumPriority) {
+  QList<ParameterBase*> params;
+  params.append( new Parameter<int >(minimumPriority));
+  stubMethodEntered("setMinimumPriority",params);
+}
+
+void NotificationFeedbackPlayerStub::init() {
+  stubMethodEntered("init");
+}
+
+void NotificationFeedbackPlayerStub::addNotification(uint id) {
+  QList<ParameterBase*> params;
+  params.append( new Parameter<uint >(id));
+  stubMethodEntered("addNotification",params);
+}
+
+void NotificationFeedbackPlayerStub::removeNotification(uint id) {
+  QList<ParameterBase*> params;
+  params.append( new Parameter<uint >(id));
+  stubMethodEntered("removeNotification",params);
+}
+
+
+
+// 3. CREATE A STUB INSTANCE
+NotificationFeedbackPlayerStub gDefaultNotificationFeedbackPlayerStub;
+NotificationFeedbackPlayerStub* gNotificationFeedbackPlayerStub = &gDefaultNotificationFeedbackPlayerStub;
+
+
+// 4. CREATE A PROXY WHICH CALLS THE STUB
+NotificationFeedbackPlayer::NotificationFeedbackPlayer(QObject *parent) {
+  gNotificationFeedbackPlayerStub->NotificationFeedbackPlayerConstructor(parent);
+}
+
+int NotificationFeedbackPlayer::minimumPriority() const {
+  return gNotificationFeedbackPlayerStub->minimumPriority();
+}
+
+void NotificationFeedbackPlayer::setMinimumPriority(int minimumPriority) {
+  gNotificationFeedbackPlayerStub->setMinimumPriority(minimumPriority);
+}
+
+void NotificationFeedbackPlayer::init() {
+  gNotificationFeedbackPlayerStub->init();
+}
+
+void NotificationFeedbackPlayer::addNotification(uint id) {
+  gNotificationFeedbackPlayerStub->addNotification(id);
+}
+
+void NotificationFeedbackPlayer::removeNotification(uint id) {
+  gNotificationFeedbackPlayerStub->removeNotification(id);
+}
+
+
+#endif

--- a/tests/stubs/notificationpreviewpresenter_stub.h
+++ b/tests/stubs/notificationpreviewpresenter_stub.h
@@ -15,6 +15,7 @@ class NotificationPreviewPresenterStub : public StubBase {
   virtual void showNextNotification();
   virtual void updateNotification(uint id);
   virtual void removeNotification(uint id, bool onlyFromQueue);
+  virtual void createWindowIfNecessary();
 }; 
 
 // 2. IMPLEMENT STUB
@@ -47,6 +48,10 @@ void NotificationPreviewPresenterStub::removeNotification(uint id, bool onlyFrom
   stubMethodEntered("removeNotification",params);
 }
 
+void NotificationPreviewPresenterStub::createWindowIfNecessary() {
+  stubMethodEntered("createWindowIfNecessary");
+}
+
 
 
 // 3. CREATE A STUB INSTANCE
@@ -77,6 +82,10 @@ void NotificationPreviewPresenter::updateNotification(uint id) {
 
 void NotificationPreviewPresenter::removeNotification(uint id, bool onlyFromQueue) {
   gNotificationPreviewPresenterStub->removeNotification(id, onlyFromQueue);
+}
+
+void NotificationPreviewPresenter::createWindowIfNecessary() {
+  gNotificationPreviewPresenterStub->createWindowIfNecessary();
 }
 
 

--- a/tests/ut_notificationfeedbackplayer/ut_notificationfeedbackplayer.h
+++ b/tests/ut_notificationfeedbackplayer/ut_notificationfeedbackplayer.h
@@ -40,6 +40,8 @@ private slots:
     void testUpdateNotificationIsNotPossibleAfterRestart();
     void testNotificationPreviewsDisabled_data();
     void testNotificationPreviewsDisabled();
+    void testNotificationPriority_data();
+    void testNotificationPriority();
 
 private:
     NotificationFeedbackPlayer *player;

--- a/tests/ut_notificationpreviewpresenter/ut_notificationpreviewpresenter.cpp
+++ b/tests/ut_notificationpreviewpresenter/ut_notificationpreviewpresenter.cpp
@@ -20,10 +20,12 @@
 #include "notificationmanager.h"
 #include "ut_notificationpreviewpresenter.h"
 #include "notificationpreviewpresenter.h"
+#include "notificationfeedbackplayer_stub.h"
 #include "lipstickcompositor_stub.h"
 #include "closeeventeater_stub.h"
 #include "qmlocks_stub.h"
 #include "qmdisplaystate_stub.h"
+#include "lipsticksettings.h"
 
 Q_DECLARE_METATYPE(NotificationPreviewPresenter*)
 Q_DECLARE_METATYPE(LipstickNotification*)
@@ -86,6 +88,11 @@ QHash<HomeWindow *, QString> homeWindowCategories;
 void HomeWindow::setCategory(const QString &category)
 {
     homeWindowCategories[this] = category;
+}
+
+LipstickSettings *LipstickSettings::instance()
+{
+    return 0;
 }
 
 const char *NotificationManager::HINT_CATEGORY = "category";
@@ -194,6 +201,7 @@ void Ut_NotificationPreviewPresenter::testSignalConnections()
     NotificationPreviewPresenter presenter;
     QCOMPARE(disconnect(NotificationManager::instance(), SIGNAL(notificationModified(uint)), &presenter, SLOT(updateNotification(uint))), true);
     QCOMPARE(disconnect(NotificationManager::instance(), SIGNAL(notificationRemoved(uint)), &presenter, SLOT(removeNotification(uint))), true);
+    QCOMPARE(disconnect(&presenter, SIGNAL(notificationPresented(uint)), presenter.notificationFeedbackPlayer, SLOT(addNotification(uint))), true);
 }
 
 void Ut_NotificationPreviewPresenter::testAddNotificationWhenWindowNotOpen()
@@ -214,6 +222,8 @@ void Ut_NotificationPreviewPresenter::testAddNotificationWhenWindowNotOpen()
     QCOMPARE(homeWindowTitle[homeWindows.first()], QString("Notification"));
     QCOMPARE(homeWindowContextProperties[homeWindows.first()].value("initialSize").toSize(), QGuiApplication::primaryScreen()->size());
     QCOMPARE(homeWindowContextProperties[homeWindows.first()].value("notificationPreviewPresenter"), QVariant::fromValue(static_cast<QObject *>(&presenter)));
+    QCOMPARE(homeWindowContextProperties[homeWindows.first()].value("notificationFeedbackPlayer"), QVariant::fromValue(static_cast<QObject *>(presenter.notificationFeedbackPlayer)));
+    QCOMPARE(homeWindowContextProperties[homeWindows.first()].contains("LipstickSettings"), true);
     QCOMPARE(homeWindowCategories[homeWindows.first()], QString("notification"));
 
     // Check that the window was shown

--- a/tests/ut_notificationpreviewpresenter/ut_notificationpreviewpresenter.pro
+++ b/tests/ut_notificationpreviewpresenter/ut_notificationpreviewpresenter.pro
@@ -14,6 +14,7 @@ SOURCES += \
 HEADERS += \
     ut_notificationpreviewpresenter.h \
     $$NOTIFICATIONSRCDIR/notificationpreviewpresenter.h \
+    $$NOTIFICATIONSRCDIR/notificationfeedbackplayer.h \
     $$NOTIFICATIONSRCDIR/notificationmanager.h \
     $$NOTIFICATIONSRCDIR/lipsticknotification.h \
     $$UTILITYSRCDIR/closeeventeater.h \


### PR DESCRIPTION
Only application notifications (urgency < 2) are affected. For system notifications the feedbacks are always played.
