### PR TITLE
send the frame callbacks to all the windows

### DIFF
--- a/src/compositor/lipstickcompositor.cpp
+++ b/src/compositor/lipstickcompositor.cpp
@@ -366,11 +366,7 @@ void LipstickCompositor::surfaceLowered()
 void LipstickCompositor::windowSwapped()
 {
 #if QT_VERSION >= QT_VERSION_CHECK(5,2,0)
-    if (m_fullscreenSurface) {
-        sendFrameCallbacks(QList<QWaylandSurface *>() << m_fullscreenSurface);
-    } else {
-        sendFrameCallbacks(surfaces());
-    }
+    sendFrameCallbacks(surfaces());
 #else
     frameFinished(0);
 #endif


### PR DESCRIPTION
We want to send the frame callbacks to all the windows, not just the fullscreen one. If the EGL stack waits for them it will block when it tries to render the cover window when the app window is fullscreen. With 5.2 that would probably be no longer the case since every window has its context (and render thread?), anyway we must not block an app which is rendering its last frame before stopping drawing.
