### PR TITLE
[lipstick] Do not intercept touch events when surface grabs keys

### DIFF
--- a/src/compositor/lipstickcompositorwindow.cpp
+++ b/src/compositor/lipstickcompositorwindow.cpp
@@ -171,7 +171,7 @@ void LipstickCompositorWindow::refreshGrabbedKeys()
 bool LipstickCompositorWindow::eventFilter(QObject *obj, QEvent *event)
 {
 #if QT_VERSION >= 0x050202
-    if (obj == window()) {
+    if (obj == window() && m_interceptingTouch) {
         switch (event->type()) {
         case QEvent::TouchUpdate: {
             QTouchEvent *te = static_cast<QTouchEvent *>(event);


### PR DESCRIPTION
When the window wanted to grab some keys, it would be registered
as event filter to the application. However, the touch interception
did not check whether the interception was enabled and always
intercepted all events directed to the compositor window.
