### PR TITLE
[lipstick] Put common objects into the root context of the engine so that they're available from all windows

### DIFF
--- a/rpm/lipstick-qt5.spec
+++ b/rpm/lipstick-qt5.spec
@@ -12,7 +12,7 @@ Name:       lipstick-qt5
 # << macros
 
 Summary:    QML toolkit for homescreen creation
-Version:    0.23.1
+Version:    0.24.0
 Release:    1
 Group:      System/Libraries
 License:    LGPLv2.1

--- a/src/homeapplication.cpp
+++ b/src/homeapplication.cpp
@@ -126,6 +126,11 @@ HomeApplication::HomeApplication(int &argc, char **argv, const QString &qmlPath)
 
     registerDBusObject(sessionBus, LIPSTICK_DBUS_SCREENSHOT_PATH, screenshotService);
 
+    // Setting up the context and engine things
+    qmlEngine->rootContext()->setContextProperty("initialSize", QGuiApplication::primaryScreen()->size());
+    qmlEngine->rootContext()->setContextProperty("lipstickSettings", LipstickSettings::instance());
+    qmlEngine->rootContext()->setContextProperty("deviceLock", deviceLock);
+
     connect(this, SIGNAL(homeReady()), this, SLOT(sendStartupNotifications()));
 }
 
@@ -266,12 +271,6 @@ HomeWindow *HomeApplication::mainWindowInstance()
     _mainWindowInstance = new HomeWindow();
     _mainWindowInstance->setGeometry(QRect(QPoint(), QGuiApplication::primaryScreen()->size()));
     _mainWindowInstance->setWindowTitle("Home");
-
-    // Setting up the context and engine things
-    _mainWindowInstance->setContextProperty("initialSize", QGuiApplication::primaryScreen()->size());
-    _mainWindowInstance->setContextProperty("LipstickSettings", LipstickSettings::instance());
-    _mainWindowInstance->setContextProperty("deviceLock", deviceLock);
-
     QObject::connect(_mainWindowInstance->engine(), SIGNAL(quit()), qApp, SLOT(quit()));
     QObject::connect(_mainWindowInstance, SIGNAL(visibleChanged(bool)), this, SLOT(connectFrameSwappedSignal(bool)));
 

--- a/src/src.pro
+++ b/src/src.pro
@@ -7,7 +7,7 @@ system(qdbusxml2cpp shutdownscreen.xml -a shutdownscreenadaptor -c ShutdownScree
 
 TEMPLATE = lib
 TARGET = lipstick-qt5
-VERSION = 0.23.1
+VERSION = 0.24.0
 
 DEFINES += QT_DISABLE_DEPRECATED_BEFORE=0x000000
 DEFINES += LIPSTICK_BUILD_LIBRARY VERSION=\\\"$$VERSION\\\"


### PR DESCRIPTION
Also renamed "LipstickSettings" to "lipstickSettings" for consistency. This requires changes in the lipstick applications.
