### PR TITLE
[path] Lipstick QmlPath API for installing files to the filesystem

### DIFF
--- a/rpm/lipstick-qt5.spec
+++ b/rpm/lipstick-qt5.spec
@@ -12,7 +12,7 @@ Name:       lipstick-qt5
 # << macros
 
 Summary:    QML toolkit for homescreen creation
-Version:    0.22.24
+Version:    0.23.0
 Release:    1
 Group:      System/Libraries
 License:    LGPLv2.1

--- a/src/connectionselector.cpp
+++ b/src/connectionselector.cpp
@@ -23,6 +23,7 @@
 #include <QTimer>
 #include "utilities/closeeventeater.h"
 #include "connectionselector.h"
+#include "lipstickqmlpath.h"
 
 ConnectionSelector::ConnectionSelector(QObject *parent) :
     QObject(parent),
@@ -44,7 +45,7 @@ void ConnectionSelector::createWindow()
     window->setWindowTitle("Connection");
     window->setContextProperty("connectionSelector", this);
     window->setContextProperty("initialSize", QGuiApplication::primaryScreen()->size());
-    window->setSource(QUrl("qrc:/qml/ConnectionSelector.qml"));
+    window->setSource(QmlPath::to("ConnectionSelector.qml"));
     window->installEventFilter(new CloseEventEater(this));
 }
 

--- a/src/lipstickqmlpath.cpp
+++ b/src/lipstickqmlpath.cpp
@@ -1,0 +1,63 @@
+// This file is part of lipstick, a QML desktop library
+//
+// Copyright (c) 2014 Jolla Ltd.
+// Contact: Thomas Perl <thomas.perl@jolla.com>
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License version 2.1 as published by the Free Software Foundation
+// and appearing in the file LICENSE.LGPL included in the packaging
+// of this file.
+//
+// This code is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+
+
+#include "lipstickqmlpath.h"
+
+#include <QFile>
+#include <QDebug>
+
+
+// Private list of paths
+static QStringList g_paths;
+
+
+void QmlPath::append(const QString &path)
+{
+    g_paths.append(path);
+}
+
+void QmlPath::prepend(const QString &path)
+{
+    g_paths.prepend(path);
+}
+
+QUrl QmlPath::to(const QString &filename)
+{
+    if (g_paths.isEmpty()) {
+        // Add default search path to not break homescreens that are not
+        // aware of the new QmlPath::append()/QmlPath::prepend() API.
+        const QString FALLBACK_PATH = ":/qml";
+        qWarning() << "Your homescreen does not use the Lipstick QmlPath API.";
+        qWarning() << "Using qrc:/ fallback; consider using QmlPath::append()";
+        g_paths.append(FALLBACK_PATH);
+    }
+
+    for (auto &dir: g_paths) {
+        QString fn = dir + "/" + filename;
+        if (QFile(fn).exists()) {
+            if (fn.startsWith(":")) {
+                return QUrl("qrc" + fn);
+            } else {
+                return QUrl::fromLocalFile(fn);
+            }
+        }
+    }
+
+    qWarning() << "QML file not found:" << filename;
+    qWarning() << "QML search path:" << g_paths;
+    return QUrl();
+}

--- a/src/lipstickqmlpath.h
+++ b/src/lipstickqmlpath.h
@@ -1,0 +1,55 @@
+// This file is part of lipstick, a QML desktop library
+//
+// Copyright (c) 2014 Jolla Ltd.
+// Contact: Thomas Perl <thomas.perl@jolla.com>
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License version 2.1 as published by the Free Software Foundation
+// and appearing in the file LICENSE.LGPL included in the packaging
+// of this file.
+//
+// This code is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+
+
+#ifndef LIPSTICK_QML_PATH_H
+#define LIPSTICK_QML_PATH_H
+
+#include <QString>
+#include <QUrl>
+
+#include "lipstickglobal.h"
+
+class LIPSTICK_EXPORT QmlPath {
+public:
+    /*!
+     * Add a new path to the Lipstick QML search path
+     *
+     * Paths added this way will be searched after all other paths.
+     *
+     * \param path The directory name where to search for QML files
+     */
+    static void append(const QString &path);
+
+    /*!
+     * Prepend a new path to the Lipstick QML search path
+     *
+     * Paths added this way will be searched before all other paths.
+     *
+     * \param path The directory name where to search for QML files
+     */
+    static void prepend(const QString &path);
+
+    /*!
+     * Resolve the path of a QML file
+     *
+     * \param filename The basename of a QML file to resolve
+     * \return A QUrl to the full path of the file (or an empty QUrl if not found)
+     */
+    static QUrl to(const QString &filename);
+};
+
+#endif /* LIPSTICK_QML_PATH_H */

--- a/src/notifications/notificationpreviewpresenter.cpp
+++ b/src/notifications/notificationpreviewpresenter.cpp
@@ -23,6 +23,7 @@
 #include "notifications/notificationfeedbackplayer.h"
 #include "compositor/lipstickcompositor.h"
 #include "notificationpreviewpresenter.h"
+#include "lipstickqmlpath.h"
 
 #include <qmdisplaystate.h>
 #include <qmlocks.h>
@@ -155,7 +156,7 @@ void NotificationPreviewPresenter::createWindowIfNecessary()
     window->setContextProperty("LipstickSettings", LipstickSettings::instance());
     window->setContextProperty("notificationPreviewPresenter", this);
     window->setContextProperty("notificationFeedbackPlayer", notificationFeedbackPlayer);
-    window->setSource(QUrl("qrc:/qml/NotificationPreview.qml"));
+    window->setSource(QmlPath::to("NotificationPreview.qml"));
     window->installEventFilter(new CloseEventEater(this));
 }
 

--- a/src/shutdownscreen.cpp
+++ b/src/shutdownscreen.cpp
@@ -24,6 +24,7 @@
 #include "notifications/notificationmanager.h"
 #include "homeapplication.h"
 #include "shutdownscreen.h"
+#include "lipstickqmlpath.h"
 
 ShutdownScreen::ShutdownScreen(QObject *parent) :
     QObject(parent),
@@ -45,7 +46,7 @@ void ShutdownScreen::setWindowVisible(bool visible)
             window->setContextProperty("initialSize", QGuiApplication::primaryScreen()->size());
             window->setContextProperty("shutdownScreen", this);
             window->setContextProperty("shutdownMode", shutdownMode);
-            window->setSource(QUrl("qrc:/qml/ShutdownScreen.qml"));
+            window->setSource(QmlPath::to("ShutdownScreen.qml"));
             window->installEventFilter(new CloseEventEater(this));
         }
 

--- a/src/src.pro
+++ b/src/src.pro
@@ -7,7 +7,7 @@ system(qdbusxml2cpp shutdownscreen.xml -a shutdownscreenadaptor -c ShutdownScree
 
 TEMPLATE = lib
 TARGET = lipstick-qt5
-VERSION = 0.22.24
+VERSION = 0.23.0
 
 DEFINES += QT_DISABLE_DEPRECATED_BEFORE=0x000000
 DEFINES += LIPSTICK_BUILD_LIBRARY VERSION=\\\"$$VERSION\\\"
@@ -32,6 +32,7 @@ PUBLICHEADERS += \
     lipstickglobal.h \
     lipsticksettings.h \
     lipstickdbus.h \
+    lipstickqmlpath.h \
     components/launcheritem.h \
     components/launchermodel.h \
     components/launcherwatchermodel.h \
@@ -65,6 +66,7 @@ HEADERS += \
     volume/volumecontrol.h \
     volume/pulseaudiocontrol.h \
     lipstickapi.h \
+    lipstickqmlpath.h \
     devicelock/devicelockadaptor.h \
     devicelock/devicelock.h \
     homeapplicationadaptor.h \
@@ -78,6 +80,7 @@ SOURCES += \
     homeapplicationadaptor.cpp \
     homewindow.cpp \
     lipsticksettings.cpp \
+    lipstickqmlpath.cpp \
     utilities/qobjectlistmodel.cpp \
     utilities/closeeventeater.cpp \
     components/launcheritem.cpp \

--- a/src/usbmodeselector.cpp
+++ b/src/usbmodeselector.cpp
@@ -21,6 +21,7 @@
 #include <qmlocks.h>
 #include "notifications/notificationmanager.h"
 #include "usbmodeselector.h"
+#include "lipstickqmlpath.h"
 
 QMap<QString, QString> USBModeSelector::errorCodeToTranslationID;
 
@@ -61,7 +62,7 @@ void USBModeSelector::setWindowVisible(bool visible)
             window->setWindowTitle("USB Mode");
             window->setContextProperty("initialSize", QGuiApplication::primaryScreen()->size());
             window->setContextProperty("usbModeSelector", this);
-            window->setSource(QUrl("qrc:/qml/USBModeSelector.qml"));
+            window->setSource(QmlPath::to("USBModeSelector.qml"));
             window->installEventFilter(new CloseEventEater(this));
         }
 

--- a/src/volume/volumecontrol.cpp
+++ b/src/volume/volumecontrol.cpp
@@ -25,6 +25,7 @@
 #include "utilities/closeeventeater.h"
 #include "pulseaudiocontrol.h"
 #include "volumecontrol.h"
+#include "lipstickqmlpath.h"
 
 VolumeControl::VolumeControl(QObject *parent) :
     QObject(parent),
@@ -90,7 +91,7 @@ void VolumeControl::setWindowVisible(bool visible)
             window->setWindowTitle("Volume");
             window->setContextProperty("initialSize", QGuiApplication::primaryScreen()->size());
             window->setContextProperty("volumeControl", this);
-            window->setSource(QUrl("qrc:/qml/VolumeControl.qml"));
+            window->setSource(QmlPath::to("VolumeControl.qml"));
             window->installEventFilter(new CloseEventEater(this));
         }
 

--- a/tests/stubs/lipstickqmlpath_stub.h
+++ b/tests/stubs/lipstickqmlpath_stub.h
@@ -1,0 +1,56 @@
+#ifndef LIPSTICKQMLPATH_STUB
+#define LIPSTICKQMLPATH_STUB
+
+#include "lipstickqmlpath.h"
+#include <stubbase.h>
+
+
+// 1. DECLARE STUB
+// FIXME - stubgen is not yet finished
+class QmlPathStub : public StubBase {
+  public:
+  virtual void append(const QString &);
+  virtual void prepend(const QString &);
+  virtual QUrl to(const QString &);
+};
+
+// 2. IMPLEMENT STUB
+void QmlPathStub::append(const QString &path) {
+  QList<ParameterBase*> params;
+  params.append(new Parameter<QString>(path));
+  stubMethodEntered("append", params);
+}
+
+void QmlPathStub::prepend(const QString &path) {
+  QList<ParameterBase*> params;
+  params.append(new Parameter<QString>(path));
+  stubMethodEntered("prepend", params);
+}
+
+QUrl QmlPathStub::to(const QString &filename) {
+  QList<ParameterBase*> params;
+  params.append(new Parameter<QString>(filename));
+  stubMethodEntered("to", params);
+  return QUrl("qrc:/qml/" + filename);
+}
+
+
+// 3. CREATE A STUB INSTANCE
+QmlPathStub gDefaultQmlPathStub;
+QmlPathStub *gQmlPathStub = &gDefaultQmlPathStub;
+
+
+// 4. CREATE A PROXY WHICH CALLS THE STUB
+void QmlPath::append(const QString &path) {
+    gQmlPathStub->append(path);
+}
+
+void QmlPath::prepend(const QString &path) {
+    gQmlPathStub->prepend(path);
+}
+
+QUrl QmlPath::to(const QString &filename) {
+    return gQmlPathStub->to(filename);
+}
+
+#endif

--- a/tests/ut_notificationpreviewpresenter/ut_notificationpreviewpresenter.cpp
+++ b/tests/ut_notificationpreviewpresenter/ut_notificationpreviewpresenter.cpp
@@ -25,6 +25,7 @@
 #include "closeeventeater_stub.h"
 #include "qmlocks_stub.h"
 #include "qmdisplaystate_stub.h"
+#include "lipstickqmlpath_stub.h"
 #include "lipsticksettings.h"
 
 Q_DECLARE_METATYPE(NotificationPreviewPresenter*)

--- a/tests/ut_shutdownscreen/ut_shutdownscreen.cpp
+++ b/tests/ut_shutdownscreen/ut_shutdownscreen.cpp
@@ -22,6 +22,7 @@
 #include "ut_shutdownscreen.h"
 #include "notificationmanager_stub.h"
 #include "closeeventeater_stub.h"
+#include "lipstickqmlpath_stub.h"
 
 QList<QQuickView *> qQuickViews;
 void QQuickView::setSource(const QUrl &)

--- a/tests/ut_usbmodeselector/ut_usbmodeselector.cpp
+++ b/tests/ut_usbmodeselector/ut_usbmodeselector.cpp
@@ -24,6 +24,7 @@
 #include "notificationmanager_stub.h"
 #include "closeeventeater_stub.h"
 #include "homewindow.h"
+#include "lipstickqmlpath_stub.h"
 
 HomeWindow::HomeWindow()
 {

--- a/tests/ut_volumecontrol/ut_volumecontrol.cpp
+++ b/tests/ut_volumecontrol/ut_volumecontrol.cpp
@@ -21,6 +21,7 @@
 #include "pulseaudiocontrol_stub.h"
 #include "closeeventeater_stub.h"
 #include "mgconfitem_stub.h"
+#include "lipstickqmlpath_stub.h"
 
 extern "C"
 {


### PR DESCRIPTION
Remove the assumption that QML files are always put into Qt Resources.

This allows implementations of homescreens to install files in the
filesystem and reference those files directly, as well as override the
path to the QML files during development easily.

Homescreens should use:
- QmlPath::append() / QmlPath::prepend() to tell Lipstick about the
  paths to the QML files (absolute file paths or starting with ":"
  for paths to Qt Resources)
- QmlPath::to() with the basename of the QML file to look up the QUrl
  of a QML file; this will be resolved using the existing paths

There is a fallback implemented that will add ":/qml" the first time
QmlPath::to() is called if no QmlPath::append() has been called before.
This allows legacy homescreens to function without change, although it
is recommended that homescreens start using QmlPath::append() and
QmlPath::to() for better integration.

Lipstick internally uses QmlPath::to() everywhere it looks up QML files.

The header "lipstickqmlpath.h" is installed as part of the public API;
version bumped to 0.23.0, which homescreen should depend on when using
the new QmlPath API and the header file.
