### PR TITLE
[lipstick] Check if the new window size is different

### DIFF
--- a/src/compositor/windowpixmapitem.cpp
+++ b/src/compositor/windowpixmapitem.cpp
@@ -311,6 +311,7 @@ void WindowPixmapItem::setWindowId(int id)
     if (m_id == id)
         return;
     
+    QSize oldSize = windowSize();
     if (m_item) {
         if (m_item->surface())
             disconnect(m_item->surface(), SIGNAL(sizeChanged()), this, SIGNAL(windowSizeChanged()));
@@ -322,6 +323,8 @@ void WindowPixmapItem::setWindowId(int id)
     updateItem();
 
     emit windowIdChanged();
+    if (windowSize() != oldSize)
+        emit windowSizeChanged();
 }
 
 bool WindowPixmapItem::opaque() const


### PR DESCRIPTION
When changing the window id used by a WindowPixmapItem we must check
if the new window has a size different than the old one, and emit
the signal.
