### PR TITLE
Fix API mismatch after QtWayland changed to offer the return value from ...

### DIFF
--- a/src/compositor/lipstickcompositor.cpp
+++ b/src/compositor/lipstickcompositor.cpp
@@ -132,10 +132,10 @@ void LipstickCompositor::surfaceCreated(QWaylandSurface *surface)
 #endif
 }
 
-void LipstickCompositor::openUrl(WaylandClient *client, const QUrl &url)
+bool LipstickCompositor::openUrl(WaylandClient *client, const QUrl &url)
 {
     Q_UNUSED(client)
-    openUrl(url);
+    return openUrl(url);
 }
 
 bool LipstickCompositor::openUrl(const QUrl &url)

--- a/src/compositor/lipstickcompositor.h
+++ b/src/compositor/lipstickcompositor.h
@@ -55,11 +55,11 @@ public:
 
     static LipstickCompositor *instance();
 
-    virtual void classBegin();
-    virtual void componentComplete();
-    virtual void surfaceCreated(QWaylandSurface *surface);
-    virtual void openUrl(WaylandClient *client, const QUrl &url);
-    virtual void retainedSelectionReceived(QMimeData *mimeData);
+    void classBegin() Q_DECL_OVERRIDE;
+    void componentComplete() Q_DECL_OVERRIDE;
+    void surfaceCreated(QWaylandSurface *surface) Q_DECL_OVERRIDE;
+    bool openUrl(WaylandClient *client, const QUrl &url) Q_DECL_OVERRIDE;
+    void retainedSelectionReceived(QMimeData *mimeData) Q_DECL_OVERRIDE;
 
     int windowCount() const;
     int ghostWindowCount() const;

--- a/tests/stubs/lipstickcompositor_stub.h
+++ b/tests/stubs/lipstickcompositor_stub.h
@@ -15,7 +15,7 @@ class LipstickCompositorStub : public StubBase {
   virtual void classBegin();
   virtual void componentComplete();
   virtual void surfaceCreated(QWaylandSurface *surface);
-  virtual void openUrl(WaylandClient *, const QUrl &);
+  virtual bool openUrl(WaylandClient *, const QUrl &);
   virtual bool openUrl(const QUrl &);
   virtual void retainedSelectionReceived(QMimeData *mimeData);
   virtual int windowCount() const;
@@ -81,11 +81,12 @@ void LipstickCompositorStub::surfaceCreated(QWaylandSurface *surface) {
   stubMethodEntered("surfaceCreated",params);
 }
 
-void LipstickCompositorStub::openUrl(WaylandClient *client, const QUrl &url) {
+bool LipstickCompositorStub::openUrl(WaylandClient *client, const QUrl &url) {
     QList<ParameterBase*> params;
     params.append( new Parameter<WaylandClient * >(client));
     params.append( new Parameter<const QUrl &>(url));
-    stubMethodEntered("openUrl",params);
+    stubMethodEntered("openUrl", params);
+    return stubReturnValue<bool>("openUrl");
 }
 
 bool LipstickCompositorStub::openUrl(const QUrl &url) {
@@ -299,8 +300,8 @@ void LipstickCompositor::surfaceCreated(QWaylandSurface *surface) {
   gLipstickCompositorStub->surfaceCreated(surface);
 }
 
-void LipstickCompositor::openUrl(WaylandClient *client, const QUrl &url) {
-  gLipstickCompositorStub->openUrl(client, url);
+bool LipstickCompositor::openUrl(WaylandClient *client, const QUrl &url) {
+  return gLipstickCompositorStub->openUrl(client, url);
 }
 
 bool LipstickCompositor::openUrl(const QUrl &url) {


### PR DESCRIPTION
...openUrl.

Also switch to use Q_DECL_OVERRIDE so these errors (if they happen again) are
clearly visible.
