### PR TITLE
Store orientationLock in dconf

### DIFF
--- a/plugin/plugin.pro
+++ b/plugin/plugin.pro
@@ -4,7 +4,7 @@ VERSION = 0.1
 
 CONFIG += qt plugin link_pkgconfig
 QT += core gui qml quick compositor dbus
-PKGCONFIG += qmsystem2-qt5
+PKGCONFIG += qmsystem2-qt5 mlite5
 
 INSTALLS = target qmldirfile
 qmldirfile.files = qmldir

--- a/src/compositor/lipstickcompositor.h
+++ b/src/compositor/lipstickcompositor.h
@@ -22,7 +22,7 @@
 #include <QWaylandCompositor>
 #include <QWaylandSurfaceItem>
 #include <QPointer>
-#include <QSettings>
+#include <MGConfItem>
 #include <qmdisplaystate.h>
 
 class WindowModel;
@@ -79,7 +79,7 @@ public:
 
     Qt::ScreenOrientation sensorOrientation() const { return m_sensorOrientation; }
 
-    QVariant orientationLock() const { return m_compositorSettings.value("Compositor/orientationLock"); }
+    QVariant orientationLock() const { return m_orientationLock->value("dynamic"); }
 
     bool displayDimmed() const { return m_previousDisplayState == MeeGo::QmDisplayState::Dimmed; }
 
@@ -91,7 +91,8 @@ public:
     Q_INVOKABLE void closeClientForWindowId(int);
     Q_INVOKABLE void clearKeyboardFocus();
     Q_INVOKABLE void setDisplayOff();
-    Q_INVOKABLE QVariant settingsValue(const QString &key, const QVariant &defaultValue = QVariant()) const { return m_compositorSettings.value("Compositor/" + key, defaultValue); }
+    Q_INVOKABLE QVariant settingsValue(const QString &key, const QVariant &defaultValue = QVariant()) const
+        { return (key == "orientationLock") ? m_orientationLock->value(defaultValue) : MGConfItem("/lipstick/" + key).value(defaultValue); }
 
     LipstickCompositorProcWindow *mapProcWindow(const QString &title, const QString &category, const QRect &);
 
@@ -188,7 +189,7 @@ private:
     MeeGo::QmDisplayState *m_displayState;
     QOrientationSensor* m_orientationSensor;
     QPointer<QMimeData> m_retainedSelection;
-    QSettings m_compositorSettings;
+    MGConfItem *m_orientationLock;
     MeeGo::QmDisplayState::DisplayState m_previousDisplayState;
     bool m_updatesEnabled;
     int m_onUpdatesDisabledUnfocusedWindowId;

--- a/tests/common.pri
+++ b/tests/common.pri
@@ -15,6 +15,8 @@ TEMPLATE = app
 DEFINES += UNIT_TEST
 DEFINES += QT_DISABLE_DEPRECATED_BEFORE=0x000000
 CONFIG -= link_prl
+CONFIG += link_pkgconfig
+PKGCONFIG += mlite5
 
 QMAKE_CXXFLAGS += \
     -Werror \


### PR DESCRIPTION
This allows (or simplifies), for example, changing orientation programmatically or from the command line and notifying all interested parties. Testers might find that useful too.
