### PR TITLE
[lipstick] enablers for devicelock pass code age

### DIFF
--- a/plugin/lipstickplugin.cpp
+++ b/plugin/lipstickplugin.cpp
@@ -26,6 +26,7 @@
 #include <notifications/notificationlistmodel.h>
 #include <notifications/lipsticknotification.h>
 #include <volume/volumecontrol.h>
+#include <devicelock/devicelock.h>
 #include <usbmodeselector.h>
 #include <shutdownscreen.h>
 #include <compositor/lipstickcompositor.h>
@@ -61,6 +62,7 @@ void LipstickPlugin::registerTypes(const char *uri)
     qmlRegisterUncreatableType<VolumeControl>("org.nemomobile.lipstick", 0, 1, "VolumeControl", "This type is initialized by HomeApplication");
     qmlRegisterUncreatableType<USBModeSelector>("org.nemomobile.lipstick", 0, 1, "USBModeSelector", "This type is initialized by HomeApplication");
     qmlRegisterUncreatableType<ShutdownScreen>("org.nemomobile.lipstick", 0, 1, "ShutdownScreen", "This type is initialized by HomeApplication");
+    qmlRegisterUncreatableType<DeviceLock>("org.nemomobile.lipstick", 0, 1, "DeviceLock", "This type is initialized by HomeApplication");
 
     qmlRegisterType<LipstickCompositor>("org.nemomobile.lipstick", 0, 1, "Compositor");
     qmlRegisterUncreatableType<QWaylandSurface>("org.nemomobile.lipstick", 0, 1, "WaylandSurface", "This type is created by the compositor");


### PR DESCRIPTION
devicelock encryption plugin is introducing new return values (exit 2 and exit 3) for special cases like lockcode is found in history file (stores xx values that config key states) and for lockcode has expired (older than xx days). This change changes boolean call to return int (but keeping the interoperability with for example jolla-home package with the kludge in lines 201-203).
