### PR TITLE
[launchermodel] : Do not dereference NULL pointer

### DIFF
--- a/src/components/launchermodel.cpp
+++ b/src/components/launchermodel.cpp
@@ -422,6 +422,7 @@ void LauncherModel::updatingProgress(const QString &packageName, int progress,
 
     if (!item) {
         qWarning() << "Package not found in model:" << packageName;
+        return;
     }
 
     item->setUpdatingProgress(progress);


### PR DESCRIPTION
If in the updating process the item does not exist, we do not only
want to warn but also not crash.

Signed-off-by: Philippe De Swert philippe.deswert@jollamobile.com
