### PR TITLE
[lipstick] serialize/hide devicelock plugin arguments

### DIFF
--- a/src/devicelock/devicelock.cpp
+++ b/src/devicelock/devicelock.cpp
@@ -51,6 +51,20 @@ static int tv_diff_in_s(const struct timeval *tv1, const struct timeval *tv2)
     return tv.tv_sec;
 }
 
+static QByteArray serialize(const QStringList &stringList)
+{
+    QByteArray byteArray;
+    QByteArray tmpArray;
+    foreach(QString v, stringList) {
+        tmpArray = v.toUtf8();
+        if (tmpArray.length() < 128) {
+            byteArray.append(tmpArray.length());
+            byteArray.append(tmpArray);
+        }
+    }
+    return byteArray;
+}
+
 DeviceLock::DeviceLock(QObject * parent) :
     QObject(parent),
     QDBusContext(),
@@ -187,7 +201,11 @@ bool DeviceLock::runPlugin(const QStringList &args)
     }
 
     QProcess process;
-    process.start(pluginName, args);
+    QByteArray serializedArgs = serialize(args);
+    process.start(pluginName);
+    process.waitForStarted(2000);
+    process.write(serializedArgs, serializedArgs.length());
+    process.closeWriteChannel();
     if (!process.waitForFinished()) {
         qWarning("Plugin did not finish in time");
         return false;


### PR DESCRIPTION
Do not merge untill devicelock encryption plugin pull request have been merged.
This pull request serializes commandline arguments so it can be piped into encryption plugin's stdin.

EDIT: new devicelock plugin has now been merged to devel. So its when this receives LGTM then someone with merge rights can merge this in.
