### PR TITLE
[lipstick] Resolve desktop file for link type exec

### DIFF
--- a/src/components/launcheritem.cpp
+++ b/src/components/launcheritem.cpp
@@ -25,6 +25,8 @@
 #include <QRegularExpressionMatch>
 #include <mdesktopentry.h>
 
+#define LINK "Link"
+
 #ifdef HAVE_CONTENTACTION
 #include <contentaction.h>
 #endif
@@ -124,7 +126,17 @@ QString LauncherItem::filename() const
 
 QString LauncherItem::exec() const
 {
-    return !_desktopEntry.isNull() ? _desktopEntry->exec() : QString();
+    QString exec = !_desktopEntry.isNull() ? _desktopEntry->exec() : QString();
+    if (!exec.isEmpty()) {
+        return exec;
+    } else if (isLink()){
+#if defined(HAVE_CONTENTACTION)
+        ContentAction::Action action = ContentAction::Action::defaultActionForScheme(_desktopEntry->url());
+        exec = action.name();
+#endif
+        return exec;
+    }
+    return QString();
 }
 
 QString LauncherItem::title() const
@@ -167,6 +179,11 @@ QString LauncherItem::titleUnlocalized() const
 bool LauncherItem::shouldDisplay() const
 {
     return !_desktopEntry.isNull() ? !_desktopEntry->noDisplay() : _isTemporary;
+}
+
+bool LauncherItem::isLink() const
+{
+    return entryType() == LINK;
 }
 
 bool LauncherItem::isValid() const

--- a/src/components/launcheritem.h
+++ b/src/components/launcheritem.h
@@ -50,6 +50,7 @@ class LIPSTICK_EXPORT LauncherItem : public QObject
     Q_PROPERTY(QStringList desktopCategories READ desktopCategories NOTIFY itemChanged)
     Q_PROPERTY(QString titleUnlocalized READ titleUnlocalized NOTIFY itemChanged)
     Q_PROPERTY(bool shouldDisplay READ shouldDisplay NOTIFY itemChanged)
+    Q_PROPERTY(bool isLink READ isLink NOTIFY itemChanged FINAL)
     Q_PROPERTY(bool isValid READ isValid NOTIFY itemChanged)
     Q_PROPERTY(bool isLaunching READ isLaunching WRITE setIsLaunching NOTIFY isLaunchingChanged)
     Q_PROPERTY(bool isUpdating READ isUpdating WRITE setIsUpdating NOTIFY isUpdatingChanged)
@@ -88,6 +89,7 @@ public:
     QStringList desktopCategories() const;
     QString titleUnlocalized() const;
     bool shouldDisplay() const;
+    bool isLink() const;
     bool isValid() const;
     bool isLaunching() const;
     bool isStillValid();

--- a/tests/ut_launchermodel/ut_launchermodel.cpp
+++ b/tests/ut_launchermodel/ut_launchermodel.cpp
@@ -109,6 +109,12 @@ MDesktopEntry::value(const QString &group, const QString &key) const
     return QString();
 }
 
+QString
+MDesktopEntry::url() const
+{
+    return "";
+}
+
 void QTimer::singleShot(int, const QObject *receiver, const char *member)
 {
     // The "member" string is of form "1member()", so remove the trailing 1 and the ()


### PR DESCRIPTION
Exec of link should not be used for launching but
can be used as an identity.

Note: When using exec as an identity and there is one desktop file for the
"normal" application launching and another one that has registered the
uri scheme, the value might not be suitable for identity usage.

This should be pushed even deeper, but don't know yet where.
