### PR TITLE
[lipstick] Don't raise or lower unmapped windows

### DIFF
--- a/src/compositor/lipstickcompositor.cpp
+++ b/src/compositor/lipstickcompositor.cpp
@@ -426,7 +426,7 @@ void LipstickCompositor::surfaceRaised()
     QWaylandSurface *surface = qobject_cast<QWaylandSurface *>(sender());
     LipstickCompositorWindow *window = surfaceWindow(surface);
 
-    if (window) {
+    if (window && window->m_mapped) {
         emit windowRaised(window);
     }
 }
@@ -436,7 +436,7 @@ void LipstickCompositor::surfaceLowered()
     QWaylandSurface *surface = qobject_cast<QWaylandSurface *>(sender());
     LipstickCompositorWindow *window = surfaceWindow(surface);
 
-    if (window) {
+    if (window && window->m_mapped) {
         emit windowLowered(window);
     }
 }


### PR DESCRIPTION
The category or other propertiy of the window may not be set yet,
producing unwanted behavior.
