### PR TITLE
[lipstick] Handle surface pings in LipstickCompositorWindow

### DIFF
--- a/src/compositor/lipstickcompositorwindow.h
+++ b/src/compositor/lipstickcompositorwindow.h
@@ -34,6 +34,7 @@ class LIPSTICK_EXPORT LipstickCompositorWindow : public QWaylandSurfaceItem
     Q_PROPERTY(qint64 processId READ processId CONSTANT)
 
     Q_PROPERTY(QRect mouseRegionBounds READ mouseRegionBounds NOTIFY mouseRegionBoundsChanged)
+    Q_PROPERTY(bool unresponsive READ unresponsive NOTIFY unresponsiveChanged)
 
 public:
     LipstickCompositorWindow(int windowId, const QString &, QWaylandQuickSurface *surface, QQuickItem *parent = 0);
@@ -50,12 +51,14 @@ public:
     QString category() const;
     virtual QString title() const;
     virtual bool isInProcess() const;
+    bool unresponsive() const;
 
     QRect mouseRegionBounds() const;
 
     bool eventFilter(QObject *object, QEvent *event);
 
     Q_INVOKABLE void terminateProcess(int killTimeout);
+    Q_INVOKABLE void ping();
 
 protected:
     virtual bool event(QEvent *);
@@ -64,6 +67,7 @@ protected:
     virtual void mouseReleaseEvent(QMouseEvent *event);
     virtual void wheelEvent(QWheelEvent *event);
     virtual void touchEvent(QTouchEvent *event);
+    virtual void timerEvent(QTimerEvent *event);
 
 signals:
     void userDataChanged();
@@ -71,11 +75,13 @@ signals:
     void delayRemoveChanged();
     void mouseRegionBoundsChanged();
     void committed();
+    void unresponsiveChanged();
 
 private slots:
     void handleTouchCancel();
     void killProcess();
     void connectSurfaceSignals();
+    void pong();
 
 private:
     friend class LipstickCompositor;
@@ -97,11 +103,13 @@ private:
     bool m_removePosted:1;
     bool m_mouseRegionValid:1;
     bool m_interceptingTouch:1;
+    bool m_mapped:1;
+    bool m_unresponsive:1;
     QVariant m_data;
     QRegion m_mouseRegion;
     QList<int> m_grabbedKeys;
     QList<QMetaObject::Connection> m_surfaceConnections;
-    bool m_mapped;
+    int m_pongTimeoutTimer;
 };
 
 #endif // LIPSTICKCOMPOSITORWINDOW_H


### PR DESCRIPTION
When a user tries to interact with an application that is not
currently responding to touch events, a visual indication
of unresponsiveness would be useful.

Added the following enablers for the visual indication:

 - Made LipstickCompositorWindow (LCW) handle the pings exclusively
    * since the surface is not exposing the serial outside,
      we need to keep only one ping in-flight at a time
 - Added a boolean property "unresponsive" to LCW
 - Added an invokable ping(timeout) to enabled pings from outside
 - LCW sends a ping on every Begin, End and Cancel touch event

A window is considered unresponsive if pong is not received
within the specified timeout. The compositor can then display
an indication after the window has remained unresponsive for a
period of time. After receiving the pong the unresponsive state
is cleared immediately.