### PR TITLE
[lipstick] don't unlock before init() has been called

### DIFF
--- a/src/devicelock/devicelock.cpp
+++ b/src/devicelock/devicelock.cpp
@@ -114,7 +114,7 @@ void DeviceLock::setupLockTimer()
 
 void DeviceLock::setStateAndSetupLockTimer()
 {
-    if (lockingDelay < 0) {
+    if (lockingDelay < 0 && deviceLockState != Undefined) {
         // Locking disabled: unlock
         setState(Unlocked);
     }


### PR DESCRIPTION
Security 'fix'. New Qt5.2 boots on device a bit slower than before, so sometimes connected signals slots are called before devicelocks "HomeApplication::homeReady" signals init() function has been called. Which leads to following statechanges "Undefined->Unlocked->Locked" even though its not abusable as Unlocked to Locked state happens within microseconds, buts still its nicer to have it working in the fashion as it should, ie not to unlock before init() has been called. After this pull request has been merged the init flow doesn't visit Unlocked-state so its "Undefined->Locked".
