### PR TITLE
Make sure all deleted windows are removed from the lists

### DIFF
--- a/src/compositor/lipstickcompositor.h
+++ b/src/compositor/lipstickcompositor.h
@@ -157,7 +157,7 @@ private:
     friend class WindowPixmapItem;
     friend class WindowProperty;
 
-    void surfaceUnmapped(LipstickCompositorProcWindow *item);
+    void surfaceUnmapped(LipstickCompositorWindow *item);
 
     int windowIdForLink(QWaylandSurface *, uint) const;
 
@@ -165,6 +165,7 @@ private:
 
     void windowAdded(int);
     void windowRemoved(int);
+    void windowDestroyed(LipstickCompositorWindow *item);
 
     QQmlComponent *shaderEffectComponent();
 

--- a/src/compositor/lipstickcompositorwindow.cpp
+++ b/src/compositor/lipstickcompositorwindow.cpp
@@ -40,6 +40,13 @@ LipstickCompositorWindow::LipstickCompositorWindow(int windowId, const QString &
     connectSurfaceSignals();
 }
 
+LipstickCompositorWindow::~LipstickCompositorWindow()
+{
+    // We don't want tryRemove() posting an event anymore, we're dying anyway
+    m_removePosted = true;
+    LipstickCompositor::instance()->windowDestroyed(this);
+}
+
 QVariant LipstickCompositorWindow::userData() const
 {
     return m_data;

--- a/src/compositor/lipstickcompositorwindow.h
+++ b/src/compositor/lipstickcompositorwindow.h
@@ -37,6 +37,7 @@ class LIPSTICK_EXPORT LipstickCompositorWindow : public QWaylandSurfaceItem
 
 public:
     LipstickCompositorWindow(int windowId, const QString &, QWaylandQuickSurface *surface, QQuickItem *parent = 0);
+    ~LipstickCompositorWindow();
 
     QVariant userData() const;
     void setUserData(QVariant);


### PR DESCRIPTION
Calling tryRemove() on a window did not ensure the window was removed from the compositor's list.
