### PR TITLE
Don't attempt to connect signal to a NULL HomeApplication

### DIFF
--- a/src/lipstickapi.cpp
+++ b/src/lipstickapi.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
 **
-** Copyright (C) 2013 Jolla Ltd.
+** Copyright (C) 2013-2014 Jolla Ltd.
 ** Contact: Aaron Kennedy <aaron.kennedy@jollamobile.com>
 **
 ** This file is part of lipstick.
@@ -21,7 +21,10 @@
 LipstickApi::LipstickApi(QObject *parent)
 : QObject(parent)
 {
-    QObject::connect(HomeApplication::instance(), SIGNAL(homeActiveChanged()), this, SIGNAL(activeChanged()));
+    HomeApplication *homeApp = HomeApplication::instance();
+    if (homeApp) {
+        QObject::connect(homeApp, SIGNAL(homeActiveChanged()), this, SIGNAL(activeChanged()));
+    }
 }
 
 bool LipstickApi::active() const


### PR DESCRIPTION
When this library is loaded into any application other than lipstick itself, HomeApplication::instance() will return NULL.

If nothing else, this gets rid of this warning:

[W] QObject::connect:2501 - QObject::connect: Cannot connect (null)::homeActiveChanged() to LipstickApi::activeChanged()
