### PR TITLE
Add a wayland interface to record the screen

### DIFF
--- a/protocol/lipstick-recorder.xml
+++ b/protocol/lipstick-recorder.xml
@@ -51,15 +51,19 @@
                 record more frames.
 
                 The buffer must be a shm buffer, trying to use another
-                type of buffer will result in frame being sent with the
-                bad_buffer result.
+                type of buffer will result in failure to capture the
+                frame and the failed event will be sent.
             </description>
             <arg name="buffer" type="object" interface="wl_buffer"/>
         </request>
 
         <enum name="result">
-            <entry name="ok" value="1"/>
             <entry name="bad_buffer" value="2"/>
+        </enum>
+
+        <enum name="transform">
+            <entry name="normal" value="1"/>
+            <entry name="y_inverted" value="2"/>
         </enum>
 
         <event name="frame">
@@ -68,14 +72,21 @@
                 recorded, or in case an error happened. The client can
                 call record_frame again to record the next frame.
 
-                The value of the 'result' argument will be one of the
-                values of the 'result' enum.
                 'time' is the time the compositor recorded that frame,
                 in milliseconds, with an unspecified base.
             </description>
-            <arg name="result" type="int"/>
             <arg name="buffer" type="object" interface="wl_buffer"/>
             <arg name="time" type="uint"/>
+            <arg name="transform" type="int"/>
+        </event>
+
+        <event name="failed">
+            <description summary="the frame capture failed">
+                The value of the 'result' argument will be one of the
+                values of the 'result' enum.
+            </description>
+            <arg name="result" type="int"/>
+            <arg name="buffer" type="object" interface="wl_buffer"/>
         </event>
 
         <event name="cancelled">

--- a/protocol/lipstick-recorder.xml
+++ b/protocol/lipstick-recorder.xml
@@ -1,0 +1,92 @@
+<protocol name="lipstick_recorder">
+    <copyright>
+        Copyright (C) 2014 Jolla Ltd.
+
+        Permission to use, copy, modify, distribute, and sell this
+        software and its documentation for any purpose is hereby granted
+        without fee, provided that the above copyright notice appear in
+        all copies and that both that copyright notice and this permission
+        notice appear in supporting documentation, and that the name of
+        the copyright holders not be used in advertising or publicity
+        pertaining to distribution of the software without specific,
+        written prior permission.  The copyright holders make no
+        representations about the suitability of this software for any
+        purpose.  It is provided "as is" without express or implied
+        warranty.
+
+        THE COPYRIGHT HOLDERS DISCLAIM ALL WARRANTIES WITH REGARD TO THIS
+        SOFTWARE, INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND
+        FITNESS, IN NO EVENT SHALL THE COPYRIGHT HOLDERS BE LIABLE FOR ANY
+        SPECIAL, INDIRECT OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+        WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN
+        AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION,
+        ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF
+        THIS SOFTWARE.
+    </copyright>
+
+    <interface name="lipstick_recorder_manager" version="1">
+        <request name="create_recorder">
+            <description summary="create a recorder object">
+                Create a recorder object for the specified output.
+            </description>
+            <arg name="recorder" type="new_id" interface="lipstick_recorder"/>
+            <arg name="output" type="object" interface="wl_output"/>
+        </request>
+    </interface>
+
+    <interface name="lipstick_recorder" version="1">
+        <request name="destroy" type="destructor">
+            <description summary="destroy the recorder object">
+                Destroy the recorder object, discarding any frame request
+                that may be pending.
+            </description>
+        </request>
+        <request name="record_frame">
+            <description summary="request a frame to be recorded">
+                Ask the compositor to record its next frame, putting
+                the content into the specified buffer data. The frame
+                event will be sent when the frame is recorded.
+                Only one frame will be recorded, the client will have
+                to call this again after the frame event if it wants to
+                record more frames.
+
+                The buffer must be a shm buffer, trying to use another
+                type of buffer will result in frame being sent with the
+                bad_buffer result.
+            </description>
+            <arg name="buffer" type="object" interface="wl_buffer"/>
+        </request>
+
+        <enum name="result">
+            <entry name="ok" value="1"/>
+            <entry name="bad_buffer" value="2"/>
+        </enum>
+
+        <event name="frame">
+            <description summary="notify a frame was recorded, or an error">
+                The compositor will send this event after a frame was
+                recorded, or in case an error happened. The client can
+                call record_frame again to record the next frame.
+
+                The value of the 'result' argument will be one of the
+                values of the 'result' enum.
+                'time' is the time the compositor recorded that frame,
+                in milliseconds, with an unspecified base.
+            </description>
+            <arg name="result" type="int"/>
+            <arg name="buffer" type="object" interface="wl_buffer"/>
+            <arg name="time" type="uint"/>
+        </event>
+
+        <event name="cancelled">
+            <description summary="notify a request was cancelled">
+                The compositor will send this event if the client calls
+                request_frame more than one time for the same compositor
+                frame. The cancel event will be sent carrying the old
+                buffer, and the frame will be recorded using the newest
+                buffer.
+            </description>
+            <arg name="buffer" type="object" interface="wl_buffer"/>
+        </event>
+    </interface>
+</protocol>

--- a/protocol/lipstick-recorder.xml
+++ b/protocol/lipstick-recorder.xml
@@ -79,6 +79,25 @@
             <entry name="y_inverted" value="2"/>
         </enum>
 
+        <event name="setup">
+            <description summary="notify the requirements for the frame buffers">
+                This event will be sent immediately after creation of the
+                lipstick_recorder object. The wl_buffers the client passes
+                to the frame request must be big enough to store an image
+                with the given width, height and format.
+                If they are not the compositor will send the failed event.
+                If this event is sent again later in the lifetime of the object
+                the pending frames will be cancelled.
+
+                The format will be one of the values as defined in the
+                wl_shm::format enum.
+            </description>
+            <arg name="width" type="int" description="width of the frame, in pixels"/>
+            <arg name="height" type="int" description="height of the frame, in pixels"/>
+            <arg name="stride" type="int" description="stride of the frame"/>
+            <arg name="format" type="int" desciption="format of the frame"/>
+        </event>
+
         <event name="frame">
             <description summary="notify a frame was recorded, or an error">
                 The compositor will send this event after a frame was

--- a/protocol/lipstick-recorder.xml
+++ b/protocol/lipstick-recorder.xml
@@ -57,6 +57,19 @@
             <arg name="buffer" type="object" interface="wl_buffer"/>
         </request>
 
+        <request name="repaint">
+            <description summary="request the compositor to repaint asap">
+                Calling record_frame will not cause the compositor to
+                repaint, but it will wait instead for the first frame
+                the compositor draws due to some other external event
+                or internal change.
+                Calling this request after calling record_frame will
+                ask the compositor to redraw as soon at possible even
+                if it wouldn't otherwise.
+                If no frame was requested this request has no effect.
+            </description>
+        </request>
+
         <enum name="result">
             <entry name="bad_buffer" value="2"/>
         </enum>

--- a/src/compositor/compositor.pri
+++ b/src/compositor/compositor.pri
@@ -13,6 +13,7 @@ PUBLICHEADERS += \
 HEADERS += \
     $$PWD/windowpixmapitem.h \
     $$PWD/windowproperty.h \
+    $$PWD/lipstickrecorder.h \
 
 SOURCES += \
     $$PWD/lipstickcompositor.cpp \
@@ -23,7 +24,10 @@ SOURCES += \
     $$PWD/windowpixmapitem.cpp \
     $$PWD/windowproperty.cpp \
     $$PWD/lipsticksurfaceinterface.cpp \
+    $$PWD/lipstickrecorder.cpp \
 
 DEFINES += QT_COMPOSITOR_QUICK
 
 QT += compositor
+
+WAYLANDSERVERSOURCES += ../protocol/lipstick-recorder.xml \

--- a/src/compositor/lipstickcompositor.h
+++ b/src/compositor/lipstickcompositor.h
@@ -29,6 +29,7 @@ class WindowModel;
 class LipstickCompositorWindow;
 class LipstickCompositorProcWindow;
 class QOrientationSensor;
+class LipstickRecorderManager;
 
 class LIPSTICK_EXPORT LipstickCompositor : public QQuickWindow, public QWaylandQuickCompositor,
                                            public QQmlParserStatus
@@ -166,6 +167,7 @@ private:
     void windowAdded(int);
     void windowRemoved(int);
     void windowDestroyed(LipstickCompositorWindow *item);
+    void readContent();
 
     QQmlComponent *shaderEffectComponent();
 
@@ -193,6 +195,7 @@ private:
     MeeGo::QmDisplayState::DisplayState m_previousDisplayState;
     bool m_updatesEnabled;
     int m_onUpdatesDisabledUnfocusedWindowId;
+    LipstickRecorderManager *m_recorder;
 };
 
 #endif // LIPSTICKCOMPOSITOR_H

--- a/src/compositor/lipstickrecorder.cpp
+++ b/src/compositor/lipstickrecorder.cpp
@@ -1,0 +1,168 @@
+/***************************************************************************
+**
+** Copyright (C) 2014 Jolla Ltd.
+** Contact: Giulio Camuffo <giulio.camuffo@jollamobile.com>
+**
+** This file is part of lipstick.
+**
+** This library is free software; you can redistribute it and/or
+** modify it under the terms of the GNU Lesser General Public
+** License version 2.1 as published by the Free Software Foundation
+** and appearing in the file LICENSE.LGPL included in the packaging
+** of this file.
+**
+****************************************************************************/
+
+#include <sys/time.h>
+
+#include <QMutexLocker>
+
+#include "lipstickrecorder.h"
+#include "lipstickcompositor.h"
+
+static uint32_t getTime()
+{
+    struct timeval tv;
+    gettimeofday(&tv, NULL);
+    return tv.tv_sec * 1000 + tv.tv_usec / 1000;
+}
+
+static const QEvent::Type FrameEventType = (QEvent::Type)QEvent::registerEventType();
+
+class FrameEvent : public QEvent
+{
+public:
+    FrameEvent(int r, uint32_t t)
+        : QEvent(FrameEventType)
+        , result(r)
+        , time(t)
+    {
+    }
+
+    int result;
+    uint32_t time;
+};
+
+LipstickRecorderManager::LipstickRecorderManager()
+                       : QWaylandGlobalInterface()
+{
+}
+
+const wl_interface* LipstickRecorderManager::interface() const
+{
+    return &lipstick_recorder_manager_interface;
+}
+
+void LipstickRecorderManager::recordFrame(QWindow *window)
+{
+    QMutexLocker lock(&m_mutex);
+    if (m_requests.isEmpty())
+        return;
+
+    uchar *pixels;
+    uint32_t time = getTime();
+    foreach (LipstickRecorder *recorder, m_requests.values(window)) {
+        wl_shm_buffer *buffer = recorder->buffer();
+        pixels = static_cast<uchar *>(wl_shm_buffer_get_data(buffer));
+        int width = wl_shm_buffer_get_width(buffer);
+        int height = wl_shm_buffer_get_height(buffer);
+
+        if (width != window->width() || height != window->height()) {
+            qApp->postEvent(recorder, new FrameEvent(QtWaylandServer::lipstick_recorder::result_bad_buffer, time));
+            continue;
+        }
+
+        glPixelStorei(GL_PACK_ALIGNMENT, 1);
+        glReadPixels(0, 0, width, height, GL_RGBA, GL_UNSIGNED_BYTE, pixels);
+        qApp->postEvent(recorder, new FrameEvent(QtWaylandServer::lipstick_recorder::result_ok, time));
+
+        m_requests.remove(window, recorder);
+    }
+}
+
+void LipstickRecorderManager::requestFrame(QWindow *window, LipstickRecorder *recorder)
+{
+    QMutexLocker lock(&m_mutex);
+    m_requests.insert(window, recorder);
+}
+
+void LipstickRecorderManager::remove(QWindow *window, LipstickRecorder *recorder)
+{
+    QMutexLocker lock(&m_mutex);
+    m_requests.remove(window, recorder);
+}
+
+void LipstickRecorderManager::bind(wl_client *client, quint32 version, quint32 id)
+{
+    Q_UNUSED(version)
+
+    add(client, id, version);
+}
+
+void LipstickRecorderManager::lipstick_recorder_manager_create_recorder(Resource *resource, uint32_t id, ::wl_resource *output)
+{
+    // TODO: we should find out the window associated with this output, but there isn't
+    // a way to do that in qtcompositor yet. Just ignore it for now and use the one window we have.
+    Q_UNUSED(output)
+
+    new LipstickRecorder(this, resource->client(), id, LipstickCompositor::instance());
+}
+
+
+LipstickRecorder::LipstickRecorder(LipstickRecorderManager *manager, wl_client *client, quint32 id, QWindow *window)
+                : QtWaylandServer::lipstick_recorder(client, id, 1)
+                , m_manager(manager)
+                , m_bufferResource(Q_NULLPTR)
+                , m_client(client)
+                , m_window(window)
+{
+}
+
+LipstickRecorder::~LipstickRecorder()
+{
+    m_manager->remove(m_window, this);
+}
+
+void LipstickRecorder::sendFrame(int result, int time)
+{
+    send_frame(result, m_bufferResource, time);
+    m_bufferResource = Q_NULLPTR;
+}
+
+void LipstickRecorder::lipstick_recorder_destroy_resource(Resource *resource)
+{
+    Q_UNUSED(resource)
+    delete this;
+}
+
+void LipstickRecorder::lipstick_recorder_destroy(Resource *resource)
+{
+    wl_resource_destroy(resource->handle);
+}
+
+void LipstickRecorder::lipstick_recorder_record_frame(Resource *resource, ::wl_resource *buffer)
+{
+    Q_UNUSED(resource)
+    if (m_bufferResource) {
+        send_cancelled(buffer);
+    }
+    m_bufferResource = buffer;
+    m_buffer = wl_shm_buffer_get(buffer);
+    if (m_buffer) {
+        m_manager->requestFrame(m_window, this);
+    } else {
+        m_bufferResource = Q_NULLPTR;
+        send_frame(result_bad_buffer, buffer, getTime());
+    }
+}
+
+bool LipstickRecorder::event(QEvent *e)
+{
+    if (e->type() == FrameEventType) {
+        FrameEvent *fe = static_cast<FrameEvent *>(e);
+        sendFrame(fe->result, fe->time);
+        wl_client_flush(client());
+        return true;
+    }
+    return QObject::event(e);
+}

--- a/src/compositor/lipstickrecorder.cpp
+++ b/src/compositor/lipstickrecorder.cpp
@@ -73,8 +73,10 @@ void LipstickRecorderManager::recordFrame(QWindow *window)
         pixels = static_cast<uchar *>(wl_shm_buffer_get_data(buffer));
         int width = wl_shm_buffer_get_width(buffer);
         int height = wl_shm_buffer_get_height(buffer);
+        int stride = wl_shm_buffer_get_stride(buffer);
+        int bpp = 4;
 
-        if (width != window->width() || height != window->height()) {
+        if (width < window->width() || height < window->height() || stride < window->width() * bpp) {
             qApp->postEvent(recorder, new FailedEvent(QtWaylandServer::lipstick_recorder::result_bad_buffer));
             continue;
         }
@@ -123,6 +125,7 @@ LipstickRecorder::LipstickRecorder(LipstickRecorderManager *manager, wl_client *
                 , m_client(client)
                 , m_window(window)
 {
+    send_setup(window->width(), window->height(), window->width() * 4, WL_SHM_FORMAT_RGBA8888);
 }
 
 LipstickRecorder::~LipstickRecorder()

--- a/src/compositor/lipstickrecorder.cpp
+++ b/src/compositor/lipstickrecorder.cpp
@@ -116,7 +116,7 @@ void LipstickRecorderManager::lipstick_recorder_manager_create_recorder(Resource
 }
 
 
-LipstickRecorder::LipstickRecorder(LipstickRecorderManager *manager, wl_client *client, quint32 id, QWindow *window)
+LipstickRecorder::LipstickRecorder(LipstickRecorderManager *manager, wl_client *client, quint32 id, QQuickWindow *window)
                 : QtWaylandServer::lipstick_recorder(client, id, 1)
                 , m_manager(manager)
                 , m_bufferResource(Q_NULLPTR)
@@ -154,6 +154,14 @@ void LipstickRecorder::lipstick_recorder_record_frame(Resource *resource, ::wl_r
     } else {
         m_bufferResource = Q_NULLPTR;
         send_failed(result_bad_buffer, buffer);
+    }
+}
+
+void LipstickRecorder::lipstick_recorder_repaint(Resource *resource)
+{
+    Q_UNUSED(resource)
+    if (m_bufferResource) {
+        m_window->update();
     }
 }
 

--- a/src/compositor/lipstickrecorder.h
+++ b/src/compositor/lipstickrecorder.h
@@ -1,0 +1,77 @@
+/***************************************************************************
+**
+** Copyright (C) 2014 Jolla Ltd.
+** Contact: Giulio Camuffo <giulio.camuffo@jollamobile.com>
+**
+** This file is part of lipstick.
+**
+** This library is free software; you can redistribute it and/or
+** modify it under the terms of the GNU Lesser General Public
+** License version 2.1 as published by the Free Software Foundation
+** and appearing in the file LICENSE.LGPL included in the packaging
+** of this file.
+**
+****************************************************************************/
+
+#ifndef LIPSTICKCOMPOSITORRECORDER_H
+#define LIPSTICKCOMPOSITORRECORDER_H
+
+#include <QObject>
+#include <QMultiHash>
+#include <QMutex>
+#include <QWaylandGlobalInterface>
+
+#include "qwayland-server-lipstick-recorder.h"
+
+struct wl_shm_buffer;
+struct wl_client;
+
+class QWindow;
+class QEvent;
+class LipstickRecorder;
+
+class LipstickRecorderManager : public QWaylandGlobalInterface, public QtWaylandServer::lipstick_recorder_manager
+{
+public:
+    LipstickRecorderManager();
+
+    const wl_interface* interface() const Q_DECL_OVERRIDE;
+
+    void recordFrame(QWindow *window);
+    void requestFrame(QWindow *window, LipstickRecorder *recorder);
+    void remove(QWindow *window, LipstickRecorder *recorder);
+
+protected:
+    void bind(wl_client *client, quint32 version, quint32 id) Q_DECL_OVERRIDE;
+    void lipstick_recorder_manager_create_recorder(Resource *resource, uint32_t id, ::wl_resource *output) Q_DECL_OVERRIDE;
+
+private:
+    QMultiHash<QWindow *, LipstickRecorder *> m_requests;
+    QMutex m_mutex;
+};
+
+class LipstickRecorder : public QObject, public QtWaylandServer::lipstick_recorder
+{
+public:
+    LipstickRecorder(LipstickRecorderManager *manager, wl_client *client, quint32 id, QWindow *window);
+    ~LipstickRecorder();
+
+    void sendFrame(int result, int time);
+    wl_shm_buffer *buffer() const { return m_buffer; }
+    wl_client *client() const { return m_client; }
+
+protected:
+    bool event(QEvent *e) Q_DECL_OVERRIDE;
+    void lipstick_recorder_destroy_resource(Resource *resource) Q_DECL_OVERRIDE;
+    void lipstick_recorder_destroy(Resource *resource) Q_DECL_OVERRIDE;
+    void lipstick_recorder_record_frame(Resource *resource, ::wl_resource *buffer) Q_DECL_OVERRIDE;
+
+private:
+    LipstickRecorderManager *m_manager;
+    wl_resource *m_bufferResource;
+    wl_shm_buffer *m_buffer;
+    wl_client *m_client;
+    QWindow *m_window;
+};
+
+#endif

--- a/src/compositor/lipstickrecorder.h
+++ b/src/compositor/lipstickrecorder.h
@@ -56,7 +56,6 @@ public:
     LipstickRecorder(LipstickRecorderManager *manager, wl_client *client, quint32 id, QWindow *window);
     ~LipstickRecorder();
 
-    void sendFrame(int result, int time);
     wl_shm_buffer *buffer() const { return m_buffer; }
     wl_client *client() const { return m_client; }
 

--- a/src/compositor/lipstickrecorder.h
+++ b/src/compositor/lipstickrecorder.h
@@ -27,6 +27,7 @@ struct wl_shm_buffer;
 struct wl_client;
 
 class QWindow;
+class QQuickWindow;
 class QEvent;
 class LipstickRecorder;
 
@@ -53,7 +54,7 @@ private:
 class LipstickRecorder : public QObject, public QtWaylandServer::lipstick_recorder
 {
 public:
-    LipstickRecorder(LipstickRecorderManager *manager, wl_client *client, quint32 id, QWindow *window);
+    LipstickRecorder(LipstickRecorderManager *manager, wl_client *client, quint32 id, QQuickWindow *window);
     ~LipstickRecorder();
 
     wl_shm_buffer *buffer() const { return m_buffer; }
@@ -64,13 +65,14 @@ protected:
     void lipstick_recorder_destroy_resource(Resource *resource) Q_DECL_OVERRIDE;
     void lipstick_recorder_destroy(Resource *resource) Q_DECL_OVERRIDE;
     void lipstick_recorder_record_frame(Resource *resource, ::wl_resource *buffer) Q_DECL_OVERRIDE;
+    void lipstick_recorder_repaint(Resource *resource) Q_DECL_OVERRIDE;
 
 private:
     LipstickRecorderManager *m_manager;
     wl_resource *m_bufferResource;
     wl_shm_buffer *m_buffer;
     wl_client *m_client;
-    QWindow *m_window;
+    QQuickWindow *m_window;
 };
 
 #endif

--- a/tests/stubs/lipstickcompositor_stub.h
+++ b/tests/stubs/lipstickcompositor_stub.h
@@ -53,6 +53,7 @@ class LipstickCompositorStub : public StubBase {
   virtual void onVisibleChanged(bool visible);
   virtual QWaylandSurfaceView *createView(QWaylandSurface *surf);
   virtual void onSurfaceDying();
+  virtual void readContent();
 }; 
 
 // 2. IMPLEMENT STUB
@@ -214,6 +215,10 @@ void LipstickCompositorStub::surfaceLowered() {
 
 void LipstickCompositorStub::onSurfaceDying() {
     stubMethodEntered("onSurfaceDying");
+}
+
+void LipstickCompositorStub::readContent() {
+    stubMethodEntered("readContent");
 }
 
 #if QT_VERSION >= QT_VERSION_CHECK(5, 2, 0)
@@ -446,6 +451,10 @@ QWaylandSurfaceView *LipstickCompositor::createView(QWaylandSurface *surf) {
 
 void LipstickCompositor::onSurfaceDying() {
     gLipstickCompositorStub->onSurfaceDying();
+}
+
+void LipstickCompositor::readContent() {
+    gLipstickCompositorStub->readContent();
 }
 
 #if QT_VERSION < QT_VERSION_CHECK(5, 2, 0)


### PR DESCRIPTION
This PR adds a protocol allowing an external client to ask lipstick to record and pass frames to it. The client can then save them to file, send them remotely, make a video...
There are a couple of open questions still: should we restrict the lipstick_recorder global to only some clients? If so, how? Should we show something on screen when it's recording?