### PR TITLE
[lipstick] Add a DBus method to notify an app is starting

### DIFF
--- a/src/components/launcherdbus.cpp
+++ b/src/components/launcherdbus.cpp
@@ -58,3 +58,8 @@ void LauncherDBus::updatingFinished(QString packageName)
 {
     m_model->updatingFinished(packageName, message().service());
 }
+
+void LauncherDBus::notifyLaunching(const QString &desktopFile)
+{
+    m_model->notifyLaunching(desktopFile);
+}

--- a/src/components/launcherdbus.h
+++ b/src/components/launcherdbus.h
@@ -42,6 +42,7 @@ public slots:
     void updatingStarted(QString packageName, QString label, QString iconPath, QString desktopFile);
     void updatingProgress(QString packageName, int progress);
     void updatingFinished(QString packageName);
+    void notifyLaunching(const QString &desktopFile);
 
 signals:
     void showUpdatingProgress(QString packageName);

--- a/src/components/launcherfoldermodel.cpp
+++ b/src/components/launcherfoldermodel.cpp
@@ -335,6 +335,8 @@ LauncherFolderModel::LauncherFolderModel(QObject *parent)
             this, SLOT(appRemoved(QObject*)));
     connect(mLauncherModel, SIGNAL(itemAdded(QObject*)),
             this, SLOT(appAdded(QObject*)));
+    connect(mLauncherModel, (void (LauncherModel::*)(LauncherItem *))&LauncherModel::notifyLaunching,
+            this, &LauncherFolderModel::notifyLaunching);
     connect(&mSaveTimer, SIGNAL(timeout()), this, SLOT(save()));
 
     QDir config;

--- a/src/components/launcherfoldermodel.h
+++ b/src/components/launcherfoldermodel.h
@@ -29,6 +29,7 @@
 class LauncherModel;
 class QXmlStreamWriter;
 class MDesktopEntry;
+class LauncherItem;
 
 class LIPSTICK_EXPORT LauncherFolderItem : public QObjectListModel
 {
@@ -117,6 +118,7 @@ public slots:
 signals:
     void directoriesChanged();
     void iconDirectoriesChanged();
+    void notifyLaunching(LauncherItem *item);
 
 private slots:
     void scheduleSave();

--- a/src/components/launchermodel.cpp
+++ b/src/components/launchermodel.cpp
@@ -460,6 +460,15 @@ void LauncherModel::updatingFinished(const QString &packageName,
     }
 }
 
+void LauncherModel::notifyLaunching(const QString &desktopFile)
+{
+    LauncherItem *item = itemInModel(desktopFile);
+    if (item)
+        emit notifyLaunching(item);
+    else
+        qWarning("No launcher item found for \"%s\".", qPrintable(desktopFile));
+}
+
 void LauncherModel::updateWatchedDBusServices()
 {
     QStringList requiredServices = _packageNameToDBusService.values();

--- a/src/components/launchermodel.h
+++ b/src/components/launchermodel.h
@@ -74,6 +74,7 @@ public:
             const QString &iconPath, QString desktopFile, const QString &serviceName);
     void updatingProgress(const QString &packageName, int progress, const QString &serviceName);
     void updatingFinished(const QString &packageName, const QString &serviceName);
+    void notifyLaunching(const QString &desktopFile);
 
     void requestLaunch(const QString &packageName);
     LauncherItem *itemInModel(const QString &path);
@@ -86,6 +87,7 @@ public slots:
 signals:
     void directoriesChanged();
     void iconDirectoriesChanged();
+    void notifyLaunching(LauncherItem *item);
 
 private:
     void reorderItems(const QMap<int, LauncherItem *> &itemsWithPositions);


### PR DESCRIPTION
The purpose of this is to show feedback to the user when he starts an app in a way which doesn't directly involve the compositor.

See https://github.com/nemomobile/mapplauncherd/pull/28