### PR TITLE
[lipstick] Don't delete the WindowPixmapItems on surface destruction

### DIFF
--- a/src/compositor/windowpixmapitem.cpp
+++ b/src/compositor/windowpixmapitem.cpp
@@ -331,7 +331,7 @@ void WindowPixmapItem::setWindowId(int id)
 
 void WindowPixmapItem::surfaceDestroyed()
 {
-    delete this;
+    setWindowId(0);
 }
 
 bool WindowPixmapItem::opaque() const


### PR DESCRIPTION
The user of WindowPixmapItem should delete it.