### PR TITLE
[lipstick] Fix devicelock tests to correspond with latest changes

### DIFF
--- a/tests/ut_devicelock/ut_devicelock.cpp
+++ b/tests/ut_devicelock/ut_devicelock.cpp
@@ -290,7 +290,7 @@ void Ut_DeviceLock::testStateOnAutomaticLockingAndTouchScreenLockState()
     QFETCH(MeeGo::QmLocks::State, touchScreenLockState);
     QFETCH(DeviceLock::LockState, deviceLockState);
 
-    deviceLock->setState(DeviceLock::Undefined);
+    deviceLock->setState(DeviceLock::Locked);
 
     deviceLock->lockingDelay = lockingDelayValue;
     gQmLocksStub->stubSetReturnValue("getState", touchScreenLockState);


### PR DESCRIPTION
Devicelock added Undefined-check fix a while back which broke this test. So fixing the test to check transition from Locked-state to Unlocked-state.