### PR TITLE
[lipstick] Add API for setting volume from QML.

### DIFF
--- a/src/homeapplication.cpp
+++ b/src/homeapplication.cpp
@@ -124,6 +124,7 @@ HomeApplication::HomeApplication(int &argc, char **argv, const QString &qmlPath)
     qmlEngine->rootContext()->setContextProperty("lipstickSettings", LipstickSettings::instance());
     qmlEngine->rootContext()->setContextProperty("LipstickSettings", LipstickSettings::instance());
     qmlEngine->rootContext()->setContextProperty("deviceLock", deviceLock);
+    qmlEngine->rootContext()->setContextProperty("volumeControl", volumeControl);
 
     connect(this, SIGNAL(homeReady()), this, SLOT(sendStartupNotifications()));
 }

--- a/src/volume/volumecontrol.h
+++ b/src/volume/volumecontrol.h
@@ -40,7 +40,7 @@ namespace ResourcePolicy {
 class LIPSTICK_EXPORT VolumeControl : public QObject
 {
     Q_OBJECT
-    Q_PROPERTY(int volume READ volume NOTIFY volumeChanged)
+    Q_PROPERTY(int volume READ volume WRITE setVolume NOTIFY volumeChanged)
     Q_PROPERTY(int maximumVolume READ maximumVolume NOTIFY maximumVolumeChanged)
     Q_PROPERTY(int safeVolume READ safeVolume NOTIFY safeVolumeChanged)
     Q_PROPERTY(bool windowVisible READ windowVisible WRITE setWindowVisible NOTIFY windowVisibleChanged)
@@ -72,6 +72,11 @@ public:
      * \return the current volume
      */
     int volume() const;
+
+    /*!
+     * Sets the current volume to \a volume.
+     */
+    void setVolume(int volume);
 
     /*!
      * Returns the maximum volume.


### PR DESCRIPTION
Make volume settable from QML. Add volume control as a global context
property so that it is available before the volume control window is
constructed.