### PR TITLE
[lipstick[ Implement basic hardware compositor support in lipstick.

### DIFF
--- a/plugin/lipstickplugin.cpp
+++ b/plugin/lipstickplugin.cpp
@@ -33,6 +33,7 @@
 #include <compositor/windowpixmapitem.h>
 #include <compositor/windowproperty.h>
 #include <lipstickapi.h>
+#include <hwcimage.h>
 
 static QObject *lipstickApi_callback(QQmlEngine *e, QJSEngine *)
 {
@@ -55,6 +56,7 @@ void LipstickPlugin::registerTypes(const char *uri)
     qmlRegisterType<LauncherItem>("org.nemomobile.lipstick", 0, 1, "LauncherItem");
     qmlRegisterType<LauncherFolderModel>("org.nemomobile.lipstick", 0, 1, "LauncherFolderModel");
     qmlRegisterType<LauncherFolderItem>("org.nemomobile.lipstick", 0, 1, "LauncherFolderItem");
+    qmlRegisterType<HwcImage>("org.nemomobile.lipstick", 0, 1, "HwcImage");
 
     qmlRegisterUncreatableType<NotificationPreviewPresenter>("org.nemomobile.lipstick", 0, 1, "NotificationPreviewPresenter", "This type is initialized by HomeApplication");
     qmlRegisterUncreatableType<NotificationFeedbackPlayer>("org.nemomobile.lipstick", 0, 1, "NotificationFeedbackPlayer", "This type is initialized by HomeApplication");

--- a/plugin/plugin.pro
+++ b/plugin/plugin.pro
@@ -12,7 +12,7 @@ qmldirfile.path = $$[QT_INSTALL_QML]/org/nemomobile/lipstick
 target.path = $$[QT_INSTALL_QML]/org/nemomobile/lipstick
 
 DEPENDPATH += "../src"
-INCLUDEPATH += "../src" "../src/utilities" "../src/xtools"
+INCLUDEPATH += "../src" "../src/utilities" "../src/xtools" "../src/compositor"
 LIBS += -L"../src" -llipstick-qt5
 
 HEADERS += \

--- a/src/compositor/compositor.pri
+++ b/src/compositor/compositor.pri
@@ -14,6 +14,8 @@ HEADERS += \
     $$PWD/windowpixmapitem.h \
     $$PWD/windowproperty.h \
     $$PWD/lipstickrecorder.h \
+    $$PWD/hwcrenderstage.h \
+    $$PWD/hwcimage.h \
 
 SOURCES += \
     $$PWD/lipstickcompositor.cpp \
@@ -25,9 +27,14 @@ SOURCES += \
     $$PWD/windowproperty.cpp \
     $$PWD/lipsticksurfaceinterface.cpp \
     $$PWD/lipstickrecorder.cpp \
+    $$PWD/hwcrenderstage.cpp \
+    $$PWD/hwcimage.cpp \
 
 DEFINES += QT_COMPOSITOR_QUICK
 
 QT += compositor
+
+# needed for hardware compositor
+QT += quick-private gui-private core-private
 
 WAYLANDSERVERSOURCES += ../protocol/lipstick-recorder.xml \

--- a/src/compositor/hwcimage.cpp
+++ b/src/compositor/hwcimage.cpp
@@ -26,6 +26,7 @@
 #include <EGL/eglext.h>
 
 static void *hwcimage_eglbuffer_to_handle(EGLClientBuffer buffer);
+static bool hwcimage_is_enabled();
 
 #define HWCIMAGE_LOAD_EVENT ((QEvent::Type) (QEvent::User + 1))
 
@@ -38,8 +39,19 @@ public:
         setAutoDelete(false);
     }
 
+    ~HwcImageLoadRequest() {
+        qCDebug(LIPSTICK_LOG_HWC, "HwcImageLoadRequest completed and destroyed...");
+    }
+
     void execute() {
         image = QImage(file).convertToFormat(QImage::Format_RGBX8888);
+
+        if (rotation != 0) {
+            QTransform xform;
+            xform.rotate(rotation);
+            image = image.transformed(xform, Qt::FastTransformation);
+        }
+
         if (textureSize.width() > 0 && textureSize.height() > 0)
             image = image.scaled(textureSize, Qt::IgnoreAspectRatio, Qt::SmoothTransformation);
 
@@ -58,6 +70,7 @@ public:
                                      Qt::IgnoreAspectRatio, Qt::SmoothTransformation);
                 p.save();
                 p.setOpacity(0.1);
+                p.setCompositionMode(QPainter::CompositionMode_Plus);
                 p.fillRect(image.rect(), glass);
                 p.restore();
             }
@@ -82,6 +95,7 @@ public:
     QColor overlay;
     QSize textureSize;
     qreal pixelRatio;
+    qreal rotation;
 
     HwcImage *hwcImage;
 
@@ -91,9 +105,10 @@ public:
 QMutex HwcImageLoadRequest::mutex;
 
 HwcImage::HwcImage()
-    : m_texture(0)
-    , m_pendingRequest(0)
+    : m_pendingRequest(0)
+    , m_rotationHandler(0)
     , m_status(Null)
+    , m_textureRotation(0)
     , m_asynchronous(true)
 {
     setFlag(ItemHasContents, true);
@@ -107,21 +122,49 @@ HwcImage::~HwcImage()
     HwcImageLoadRequest::mutex.unlock();
 }
 
+
+/* We want to track the item that does rotation changes explicitly. This isn't
+   strictly needed, but it is easy to do and means we get away with tracking
+   one single object as opposed to listening for changes in an entire parent
+   hierarchy which would also be a lot slower.
+  */
+void HwcImage::setRotationHandler(QQuickItem *item)
+{
+    if (!hwcimage_is_enabled()) {
+        qCDebug(LIPSTICK_LOG_HWC, "HwcImage ignoring rotation handler as HWC is disabled");
+        return;
+    }
+
+    if (m_rotationHandler == item)
+        return;
+    if (m_rotationHandler)
+        disconnect(m_rotationHandler, &QQuickItem::rotationChanged, this, &HwcImage::handlerRotationChanged);
+    m_rotationHandler = item;
+    if (m_rotationHandler)
+        connect(m_rotationHandler, &QQuickItem::rotationChanged, this, &HwcImage::handlerRotationChanged);
+    emit rotationHandlerChanged();
+    polish();
+
+    qCDebug(LIPSTICK_LOG_HWC) << "HwcImage" << this << "tracking rotation handler" << item;
+}
+
 void HwcImage::setAsynchronous(bool is)
 {
     if (m_asynchronous == is)
         return;
     m_asynchronous = is;
-    emit asynchronousChanged(m_asynchronous);
+    emit asynchronousChanged();
     polish();
 }
 
 void HwcImage::setSource(const QUrl &source)
 {
-	if (source == m_source)
-		return;
-	m_source = source;
-    emit sourceChanged(m_source);
+    if (source == m_source)
+        return;
+    m_source = source;
+    emit sourceChanged();
+    m_status = Loading;
+    emit statusChanged();
     polish();
 }
 
@@ -130,7 +173,7 @@ void HwcImage::setOverlayColor(const QColor &color)
     if (m_overlayColor == color)
         return;
     m_overlayColor = color;
-    emit overlayColorChanged(m_overlayColor);
+    emit overlayColorChanged();
     polish();
 }
 
@@ -139,7 +182,7 @@ void HwcImage::setTextureSize(const QSize &size)
     if (m_textureSize == size)
         return;
     m_textureSize = size;
-    emit textureSizeChanged(m_textureSize);
+    emit textureSizeChanged();
     polish();
 }
 
@@ -148,7 +191,7 @@ void HwcImage::setEffect(const QString &effect)
     if (m_effect == effect)
         return;
     m_effect = effect;
-    emit effectChanged(m_effect);
+    emit effectChanged();
     polish();
 }
 
@@ -157,8 +200,15 @@ void HwcImage::setPixelRatio(qreal ratio)
     if (m_pixelRatio == ratio)
         return;
     m_pixelRatio = ratio;
-    emit pixelRatioChanged(m_pixelRatio);
+    emit pixelRatioChanged();
     polish();
+}
+
+void HwcImage::handlerRotationChanged()
+{
+    qreal rotation = m_rotationHandler->rotation();
+    if ((rotation == 0 || rotation == 90 || rotation == 180 || rotation == 270) && m_textureRotation != rotation)
+        polish();
 }
 
 void HwcImage::updatePolish()
@@ -166,7 +216,7 @@ void HwcImage::updatePolish()
     if (m_source.isEmpty())
         return;
     m_status = Loading;
-    emit statusChanged(m_status);
+    emit statusChanged();
 
     m_image = QImage();
     HwcImageLoadRequest *req = new HwcImageLoadRequest();
@@ -176,6 +226,18 @@ void HwcImage::updatePolish()
     req->effect = m_effect;
     req->overlay = m_overlayColor;
     req->pixelRatio = m_pixelRatio;
+    req->rotation = m_rotationHandler ? m_rotationHandler->rotation() : 0;
+
+    qCDebug(LIPSTICK_LOG_HWC,
+            "Scheduling HwcImage request, source=%s, (%d x %d), eff=%s, olay=%s, rot=%f, pr=%f, %s",
+            qPrintable(m_source.toString()),
+            m_textureSize.width(), m_textureSize.height(),
+            qPrintable(m_effect),
+            qPrintable(m_overlayColor.name(QColor::HexArgb)),
+            req->rotation,
+            m_pixelRatio,
+            (m_asynchronous ? "async" : "sync")
+            );
 
     if (m_asynchronous) {
         HwcImageLoadRequest::mutex.lock();
@@ -195,7 +257,8 @@ void HwcImage::apply(HwcImageLoadRequest *req)
     QSize s = m_image.size();
     setSize(s);
     m_status = s.isValid() ? Ready : Error;
-    emit statusChanged(m_status);
+    emit statusChanged();
+    m_textureRotation = req->rotation;
     update();
 }
 
@@ -203,13 +266,24 @@ bool HwcImage::event(QEvent *e)
 {
     if (e->type() == HWCIMAGE_LOAD_EVENT) {
         HwcImageLoadRequest *req = static_cast<HwcImageLoadRequest *>(e);
-        if (m_source.toLocalFile() == req->file
-            && m_effect == req->effect
-            && m_textureSize == req->textureSize
-            && m_pixelRatio == req->pixelRatio
-            && m_overlayColor == req->overlay) {
+
+        bool accept = m_source.toLocalFile() == req->file
+                      && m_effect == req->effect
+                      && m_textureSize == req->textureSize
+                      && m_pixelRatio == req->pixelRatio
+                      && m_overlayColor == req->overlay;
+        qCDebug(LIPSTICK_LOG_HWC,
+                "HwcImage request completed: %s, source=%s, (%d x %d), eff=%s, olay=%s, rot=%f, pr=%f",
+                (accept ? "accepted" : "rejected"),
+                qPrintable(req->file),
+                req->textureSize.width(), req->textureSize.height(),
+                qPrintable(req->effect),
+                qPrintable(req->overlay.name(QColor::HexArgb)),
+                req->rotation,
+                req->pixelRatio);
+        if (accept)
             apply(req);
-        }
+
         return true;
     }
     return QQuickItem::event(e);
@@ -244,8 +318,14 @@ private:
 class HwcImageNode : public QSGSimpleTextureNode
 {
 public:
-    HwcImageNode() { qsgnode_set_description(this, "hwc-image-node"); }
-    ~HwcImageNode() { delete texture(); }
+    HwcImageNode() {
+        qCDebug(LIPSTICK_LOG_HWC) << "HwcImageNode is created...";
+        qsgnode_set_description(this, QStringLiteral("hwc-image-node"));
+    }
+    ~HwcImageNode() {
+        qCDebug(LIPSTICK_LOG_HWC) << "HwcImageNode is gone...";
+        delete texture();
+    }
     void *handle() const {
         HwcImageTexture *t = static_cast<HwcImageTexture *>(texture());
         return t ? t->handle() : 0;
@@ -276,42 +356,71 @@ HwcImageNode *HwcImage::updateActualPaintNode(QSGNode *old)
     return tn;
 }
 
+QMatrix4x4 HwcImage::reverseTransform() const
+{
+    if (!m_rotationHandler)
+        return QMatrix4x4();
+    // We assume a center-oriented rotation with no monkey busines between us
+    // and the rotationHandler and the rotationHandler must be a parent of
+    // ourselves. (It wouldn't rotate otherwise)
+    float w2 = width() / 2;
+    float h2 = height() / 2;
+    QMatrix4x4 m;
+    m.translate(w2, h2);
+    m.rotate(-m_textureRotation, 0, 0, 1);
+    m.translate(-w2, -h2);
+    return m;
+}
+
 QSGNode *HwcImage::updatePaintNode(QSGNode *old, UpdatePaintNodeData *)
 {
-    // Check for availablility of EGL_HYBRIS_native_buffer support, which we
-    // need to do hwc layering of background images...
-    static int hybrisBuffers = -1;
-    if (hybrisBuffers < 0) {
-        if (strstr(eglQueryString(eglGetCurrentDisplay(), EGL_EXTENSIONS), "EGL_HYBRIS_native_buffer") == 0)
-            hybrisBuffers = 0;
-        else
-            hybrisBuffers = 1;
+    if (!hwcimage_is_enabled()) {
+        qCDebug(LIPSTICK_LOG_HWC) << "HwcImage" << this << "updating paint node without HWC support";
+        return updateActualPaintNode(old);
     }
 
-    if (!HwcRenderStage::isHwcEnabled())
-        return updateActualPaintNode(old);
+    /*
+        When we're using hwcomposer, we replace the image with a slightly more
+        complex subtree. There is an HwcNode which is where we put the buffer
+        handle which the HwcRenderStage will pick up. Then we have a
+        QSGTransformNode which we use to apply reverse transforms. For different
+        orientations we create a rotated texture and invert the transform
+        in the scene graph.
 
+        HwcNode             <- The hook which makes us get picked up by the HwcRenderStage
+           |
+        QSGTransformNode    <- The reverse transform used to get correct orientation
+           |
+        HwcImageNode        <- The texture node which gets rendered as a fallback.
+     */
     if (old) {
+        qCDebug(LIPSTICK_LOG_HWC) << "HwcImage" << this << "updating paint existing node";
         HwcNode *hwcNode = static_cast<HwcNode *>(old);
-        HwcImageNode *contentNode = updateActualPaintNode(hwcNode->firstChild());
+        HwcImageNode *contentNode = updateActualPaintNode(hwcNode->firstChild()->firstChild());
         if (contentNode == 0) {
             delete hwcNode;
             return 0;
-        } else if (contentNode != hwcNode->firstChild()) {
+        } else if (contentNode != hwcNode->firstChild()->firstChild()) {
             // No need to remove the old node as the updatePaintNode call will
             // already have deleted the old content node and it would thus have
             // already been taken out.
-            hwcNode->appendChildNode(contentNode);
+            hwcNode->firstChild()->appendChildNode(contentNode);
         }
-        hwcNode->update(contentNode->handle());
+        static_cast<QSGTransformNode *>(hwcNode->firstChild())->setMatrix(reverseTransform());
+        hwcNode->update(contentNode, contentNode->handle());
         return hwcNode;
     }
 
     HwcImageNode *contentNode = updateActualPaintNode(0);
     if (contentNode) {
+        qCDebug(LIPSTICK_LOG_HWC) << "HwcImage" << this << "creating new node";
         HwcNode *hwcNode = new HwcNode();
-        hwcNode->appendChildNode(contentNode);
-        hwcNode->update(contentNode->handle());
+        QSGTransformNode *xnode = new QSGTransformNode();
+        xnode->setMatrix(reverseTransform());
+        qsgnode_set_description(xnode, QStringLiteral("hwc-reverse-xform"));
+        xnode->appendChildNode(contentNode);
+        hwcNode->appendChildNode(xnode);
+        hwcNode->update(contentNode, contentNode->handle());
         return hwcNode;
     }
 
@@ -356,6 +465,7 @@ static void hwcimage_initialize()
         return;
     initialized = true;
 
+
     glEGLImageTargetTexture2DOES = (_glEGLImageTargetTexture2DOES) eglGetProcAddress("glEGLImageTargetTexture2DOES");
     eglCreateImageKHR = (_eglCreateImageKHR) eglGetProcAddress("eglCreateImageKHR");
     eglDestroyImageKHR = (_eglDestroyImageKHR) eglGetProcAddress("eglDestroyImageKHR");
@@ -365,9 +475,26 @@ static void hwcimage_initialize()
     eglHybrisReleaseNativeBuffer = (_eglHybrisReleaseNativeBuffer) eglGetProcAddress("eglHybrisReleaseNativeBuffer");
 }
 
+static bool hwcimage_is_enabled()
+{
+    // Check for availablility of EGL_HYBRIS_native_buffer support, which we
+    // need to do hwc layering of background images...
+    static int hybrisBuffers = -1;
+    if (hybrisBuffers < 0) {
+        if (strstr(eglQueryString(eglGetDisplay(EGL_DEFAULT_DISPLAY), EGL_EXTENSIONS), "EGL_HYBRIS_native_buffer") == 0)
+            hybrisBuffers = 0;
+        else
+            hybrisBuffers = 1;
+    }
+    return hybrisBuffers == 1 && HwcRenderStage::isHwcEnabled();
+}
+
 QSGTexture *HwcImageTexture::create(const QImage &image)
 {
     hwcimage_initialize();
+
+    if (!hwcimage_is_enabled())
+        return 0;
 
     EGLClientBuffer buffer = 0;
     int width = image.width();
@@ -408,6 +535,9 @@ HwcImageTexture::HwcImageTexture(EGLClientBuffer buffer, EGLImageKHR image, cons
     , m_bound(false)
 {
     glGenTextures(1, &m_id);
+    qCDebug(LIPSTICK_LOG_HWC,
+            "HwcImageTexture(%p) created, size=(%d x %d), texId=%d, buffer=%p, image=%p",
+            this, m_size.width(), m_size.height(), m_id, m_buffer, m_image);
 }
 
 HwcImageTexture::~HwcImageTexture()
@@ -415,6 +545,9 @@ HwcImageTexture::~HwcImageTexture()
     glDeleteTextures(1, &m_id);
     eglDestroyImageKHR(eglGetDisplay(EGL_DEFAULT_DISPLAY), m_image);
     eglHybrisReleaseNativeBuffer(m_buffer);
+    qCDebug(LIPSTICK_LOG_HWC,
+            "HwcImageTexture(%p) destroyed, size=(%d x %d), texId=%d, buffer=%p, image=%p",
+            this, m_size.width(), m_size.height(), m_id, m_buffer, m_image);
 }
 
 void HwcImageTexture::bind()

--- a/src/compositor/hwcimage.cpp
+++ b/src/compositor/hwcimage.cpp
@@ -1,0 +1,324 @@
+/***************************************************************************
+**
+** Copyright (C) 2015 Jolla Ltd.
+** Contact: Gunnar Sletta <gunnar.sletta@jollamobile.com>
+**
+** This file is part of lipstick.
+**
+** This library is free software; you can redistribute it and/or
+** modify it under the terms of the GNU Lesser General Public
+** License version 2.1 as published by the Free Software Foundation
+** and appearing in the file LICENSE.LGPL included in the packaging
+** of this file.
+**
+****************************************************************************/
+
+#include "hwcimage.h"
+#include "hwcrenderstage.h"
+
+#include <QQuickWindow>
+#include <QSGSimpleTextureNode>
+
+#include <EGL/egl.h>
+#include <EGL/eglext.h>
+
+static void *hwcimage_eglbuffer_to_handle(EGLClientBuffer buffer);
+
+HwcImage::HwcImage()
+    : m_status(Null)
+    , m_darkness(0)
+{
+    setFlag(ItemHasContents, true);
+}
+
+HwcImage::~HwcImage()
+{
+
+}
+
+void HwcImage::setSource(const QUrl &source)
+{
+	if (source == m_source)
+		return;
+	m_source = source;
+    emit sourceChanged();
+    polish();
+}
+
+void HwcImage::setDarkness(qreal darkness)
+{
+    qreal d = qBound<qreal>(0, darkness, 1);
+    if (m_darkness == d)
+        return;
+    m_darkness = d;
+    emit darknessChanged();
+    polish();
+}
+
+
+void HwcImage::updatePolish()
+{
+    if (m_source.isEmpty())
+        return;
+
+    m_status = Loading;
+    emit statusChanged();
+
+    QString file = m_source.toLocalFile();
+    m_image = QImage(file).convertToFormat(QImage::Format_RGBX8888);
+    setWidth(m_image.width());
+    setHeight(m_image.height());
+    if (m_image.size().isValid()) {
+        m_status = Ready;
+        QPainter p(&m_image);
+        p.fillRect(m_image.rect(), QColor::fromRgbF(0, 0, 0, m_darkness));
+    } else {
+        m_status = Error;
+    }
+    emit statusChanged();
+    update();
+}
+
+
+
+class HwcImageTexture : public QSGTexture
+{
+public:
+    HwcImageTexture(EGLClientBuffer buffer, EGLImageKHR image, const QSize &size);
+    ~HwcImageTexture();
+
+    int textureId() const { return m_id; }
+    QSize textureSize() const { return m_size; }
+    bool hasAlphaChannel() const { return false; }
+    bool hasMipmaps() const { return false; }
+    void bind();
+
+    static QSGTexture *create(const QImage &image);
+
+    void *handle() const { return hwcimage_eglbuffer_to_handle(m_buffer); }
+
+private:
+    GLuint m_id;
+    EGLClientBuffer m_buffer;
+    EGLImageKHR m_image;
+    QSize m_size;
+    void *m_handle;
+    bool m_bound;
+};
+
+
+class HwcImageNode : public QSGSimpleTextureNode
+{
+public:
+    HwcImageNode() { qsgnode_set_description(this, "hwc-image-node"); }
+    ~HwcImageNode() { delete texture(); }
+    void *handle() const {
+        HwcImageTexture *t = static_cast<HwcImageTexture *>(texture());
+        qDebug() << "asking for handle from" << this << t << (t ? t->handle() : 0);
+        return t ? t->handle() : 0;
+    }
+};
+
+HwcImageNode *HwcImage::updateActualPaintNode(QSGNode *old)
+{
+    if (m_image.isNull() || width() <= 0 || height() <= 0) {
+        delete old;
+        return 0;
+    }
+
+    HwcImageNode *tn = static_cast<HwcImageNode *>(old);
+    if (!tn)
+        tn = new HwcImageNode();
+    if (!tn->texture() || !m_image.isNull()) {
+        if (tn->texture())
+            delete tn->texture();
+        QSGTexture *t = HwcImageTexture::create(m_image);
+        if (t)
+            tn->setTexture(t);
+        else
+            tn->setTexture(window()->createTextureFromImage(m_image));
+        m_image = QImage();
+    }
+    tn->setRect(0, 0, width(), height());
+    return tn;
+}
+
+QSGNode *HwcImage::updatePaintNode(QSGNode *old, UpdatePaintNodeData *)
+{
+    // Check for availablility of EGL_HYBRIS_native_buffer support, which we
+    // need to do hwc layering of background images...
+    static int hybrisBuffers = -1;
+    if (hybrisBuffers < 0) {
+        if (strstr(eglQueryString(eglGetCurrentDisplay(), EGL_EXTENSIONS), "EGL_HYBRIS_native_buffer") == 0)
+            hybrisBuffers = 0;
+        else
+            hybrisBuffers = 1;
+    }
+
+    if (!HwcRenderStage::isHwcEnabled())
+        return updateActualPaintNode(old);
+
+    if (old) {
+        HwcNode *hwcNode = static_cast<HwcNode *>(old);
+        HwcImageNode *contentNode = updateActualPaintNode(hwcNode->firstChild());
+        if (contentNode == 0) {
+            delete hwcNode;
+            return 0;
+        } else if (contentNode != hwcNode->firstChild()) {
+            // No need to remove the old node as the updatePaintNode call will
+            // already have deleted the old content node and it would thus have
+            // already been taken out.
+            hwcNode->appendChildNode(contentNode);
+        }
+        hwcNode->update(contentNode->handle());
+        return hwcNode;
+    }
+
+    HwcImageNode *contentNode = updateActualPaintNode(0);
+    if (contentNode) {
+        HwcNode *hwcNode = new HwcNode();
+        hwcNode->appendChildNode(contentNode);
+        hwcNode->update(contentNode->handle());
+        return hwcNode;
+    }
+
+    return 0;
+}
+
+
+// from hybris_nativebuffer.h in libhybris
+#define HYBRIS_USAGE_SW_WRITE_RARELY    0x00000020
+#define HYBRIS_USAGE_HW_TEXTURE         0x00000100
+#define HYBRIS_USAGE_HW_COMPOSER        0x00000800
+#define HYBRIS_PIXEL_FORMAT_RGBA_8888   1
+#define HYBRIS_PIXEL_FORMAT_RGB_888     3
+#define HYBRIS_PIXEL_FORMAT_BGRA_8888   5
+
+#define EGL_NATIVE_BUFFER_HYBRIS             0x3140
+
+extern "C" {
+    typedef EGLBoolean (EGLAPIENTRYP _eglHybrisCreateNativeBuffer)(EGLint width, EGLint height, EGLint usage, EGLint format, EGLint *stride, EGLClientBuffer *buffer);
+    typedef EGLBoolean (EGLAPIENTRYP _eglHybrisLockNativeBuffer)(EGLClientBuffer buffer, EGLint usage, EGLint l, EGLint t, EGLint w, EGLint h, void **vaddr);
+    typedef EGLBoolean (EGLAPIENTRYP _eglHybrisUnlockNativeBuffer)(EGLClientBuffer buffer);
+    typedef EGLBoolean (EGLAPIENTRYP _eglHybrisReleaseNativeBuffer)(EGLClientBuffer buffer);
+
+    typedef void (EGLAPIENTRYP _glEGLImageTargetTexture2DOES)(GLenum target, EGLImageKHR image);
+    typedef EGLImageKHR (EGLAPIENTRYP _eglCreateImageKHR)(EGLDisplay dpy, EGLContext ctx, EGLenum target, EGLClientBuffer buffer, const EGLint *attribs);
+    typedef EGLBoolean (EGLAPIENTRYP _eglDestroyImageKHR)(EGLDisplay dpy, EGLImageKHR image);
+}
+
+_glEGLImageTargetTexture2DOES glEGLImageTargetTexture2DOES = 0;
+_eglCreateImageKHR eglCreateImageKHR = 0;
+_eglDestroyImageKHR eglDestroyImageKHR = 0;
+
+_eglHybrisCreateNativeBuffer eglHybrisCreateNativeBuffer = 0;
+_eglHybrisLockNativeBuffer eglHybrisLockNativeBuffer = 0;
+_eglHybrisUnlockNativeBuffer eglHybrisUnlockNativeBuffer = 0;
+_eglHybrisReleaseNativeBuffer eglHybrisReleaseNativeBuffer = 0;
+
+static void hwcimage_initialize()
+{
+    static bool initialized = false;
+    if (initialized)
+        return;
+    initialized = true;
+
+    glEGLImageTargetTexture2DOES = (_glEGLImageTargetTexture2DOES) eglGetProcAddress("glEGLImageTargetTexture2DOES");
+    eglCreateImageKHR = (_eglCreateImageKHR) eglGetProcAddress("eglCreateImageKHR");
+    eglDestroyImageKHR = (_eglDestroyImageKHR) eglGetProcAddress("eglDestroyImageKHR");
+    eglHybrisCreateNativeBuffer = (_eglHybrisCreateNativeBuffer) eglGetProcAddress("eglHybrisCreateNativeBuffer");
+    eglHybrisLockNativeBuffer = (_eglHybrisLockNativeBuffer) eglGetProcAddress("eglHybrisLockNativeBuffer");
+    eglHybrisUnlockNativeBuffer = (_eglHybrisUnlockNativeBuffer) eglGetProcAddress("eglHybrisUnlockNativeBuffer");
+    eglHybrisReleaseNativeBuffer = (_eglHybrisReleaseNativeBuffer) eglGetProcAddress("eglHybrisReleaseNativeBuffer");
+}
+
+QSGTexture *HwcImageTexture::create(const QImage &image)
+{
+    hwcimage_initialize();
+
+    EGLClientBuffer buffer = 0;
+    int width = image.width();
+    int height = image.height();
+    int usage = HYBRIS_USAGE_SW_WRITE_RARELY | HYBRIS_USAGE_HW_TEXTURE | HYBRIS_USAGE_HW_COMPOSER;
+    int stride = 0;
+    int format = HYBRIS_PIXEL_FORMAT_RGBA_8888;
+    char *data;
+
+    eglHybrisCreateNativeBuffer(width, height, usage, format, &stride, &buffer);
+    Q_ASSERT(buffer);
+    eglHybrisLockNativeBuffer(buffer, HYBRIS_USAGE_SW_WRITE_RARELY, 0, 0, width, height, (void **) &data);
+    Q_ASSERT(data);
+
+    const int dbpl = stride * 4;
+    const int bpl = qMin(dbpl, image.bytesPerLine());
+    for (int y=0; y<height; ++y)
+        memcpy(data + y * dbpl, image.constScanLine(y), bpl);
+
+    eglHybrisUnlockNativeBuffer(buffer);
+
+    EGLImageKHR eglImage = eglCreateImageKHR(eglGetDisplay(EGL_DEFAULT_DISPLAY),
+                                             EGL_NO_CONTEXT,
+                                             EGL_NATIVE_BUFFER_HYBRIS,
+                                             buffer,
+                                             0);
+    Q_ASSERT(eglImage);
+
+    return new HwcImageTexture(buffer, eglImage, QSize(width, height));
+
+}
+
+
+HwcImageTexture::HwcImageTexture(EGLClientBuffer buffer, EGLImageKHR image, const QSize &size)
+    : m_buffer(buffer)
+    , m_image(image)
+    , m_size(size)
+    , m_bound(false)
+{
+    glGenTextures(1, &m_id);
+}
+
+HwcImageTexture::~HwcImageTexture()
+{
+    glDeleteTextures(1, &m_id);
+    eglDestroyImageKHR(eglGetDisplay(EGL_DEFAULT_DISPLAY), m_image);
+    eglHybrisReleaseNativeBuffer(m_buffer);
+}
+
+void HwcImageTexture::bind()
+{
+    updateBindOptions();
+    glBindTexture(GL_TEXTURE_2D, m_id);
+    if (!m_bound) {
+        m_bound = true;
+        glEGLImageTargetTexture2DOES(GL_TEXTURE_2D, m_image);
+    }
+}
+
+
+// Memory layout of ANativeWindowBuffer from Android's /system/window.h which
+// is the structure that libhybris uses internally to represent the actual
+// EGLClientBuffer. We need this to extract the gralloc handle.
+struct android_native_base_t {
+    int magic;
+    int version;
+    void *reserved[4];
+    void (*incRef)(struct android_native_base_t* base);
+    void (*decRef)(struct android_native_base_t* base);
+};
+struct ANativeWindowBuffer {
+    android_native_base_t common;
+    int width;
+    int height;
+    int stride;
+    int format;
+    int usage;
+    void *reserved[2];
+    void *handle;
+    void *reserved_proc[8];
+};
+
+void *hwcimage_eglbuffer_to_handle(EGLClientBuffer buffer)
+{
+    return ((ANativeWindowBuffer *) buffer)->handle;
+}
+

--- a/src/compositor/hwcimage.h
+++ b/src/compositor/hwcimage.h
@@ -35,8 +35,9 @@ class LIPSTICK_EXPORT HwcImage : public QQuickItem
     Q_PROPERTY(QColor overlayColor READ overlayColor WRITE setOverlayColor NOTIFY overlayColorChanged)
     Q_PROPERTY(qreal pixelRatio READ pixelRatio WRITE setPixelRatio NOTIFY pixelRatioChanged)
     Q_PROPERTY(QSize textureSize READ textureSize WRITE setTextureSize NOTIFY textureSizeChanged)
-    Q_PROPERTY(QString effect READ effect WRITE setEffect NOTIFY effectChanged);
-    Q_PROPERTY(bool asynchronous READ isAsynchronous WRITE setAsynchronous WRITE asynchronousChanged)
+    Q_PROPERTY(QString effect READ effect WRITE setEffect NOTIFY effectChanged)
+    Q_PROPERTY(QQuickItem *rotationHandler READ rotationHandler WRITE setRotationHandler NOTIFY rotationHandlerChanged)
+    Q_PROPERTY(bool asynchronous READ isAsynchronous WRITE setAsynchronous NOTIFY asynchronousChanged)
 
     Q_ENUMS(Status)
 
@@ -64,7 +65,10 @@ public:
     qreal pixelRatio() const { return m_pixelRatio; }
 
     void setAsynchronous(bool is);
-    bool isAsynchronous() const;
+    bool isAsynchronous() const { return m_asynchronous; }
+
+    void setRotationHandler(QQuickItem *rotationHandler);
+    QQuickItem *rotationHandler() const { return m_rotationHandler; }
 
 protected:
     bool event(QEvent *event);
@@ -73,23 +77,26 @@ protected:
 	QSGNode *updatePaintNode(QSGNode *node, UpdatePaintNodeData *data);
 
 signals:
-    void sourceChanged(const QUrl &url);
-    void statusChanged(Status s);
-    void overlayColorChanged(const QColor &color);
-    void textureSizeChanged(const QSize &size);
-    void effectChanged(const QString &effect);
-    void pixelRatioChanged(qreal pr);
-    void asynchronousChanged(bool async);
+    void sourceChanged();
+    void statusChanged();
+    void overlayColorChanged();
+    void textureSizeChanged();
+    void effectChanged();
+    void pixelRatioChanged();
+    void asynchronousChanged();
+    void rotationHandlerChanged();
+
+private slots:
+    void handlerRotationChanged();
 
 private:
     friend class HwcImageLoadRequest;
     void apply(HwcImageLoadRequest *);
+    QMatrix4x4 reverseTransform() const;
     HwcImageNode *updateActualPaintNode(QSGNode *node);
 
-    QSGTexture *m_texture;
-
     HwcImageLoadRequest *m_pendingRequest;
-
+    QQuickItem *m_rotationHandler;
 	QUrl m_source;
     QImage m_image;
     QSize m_textureSize;
@@ -97,6 +104,7 @@ private:
     Status m_status;
     QColor m_overlayColor;
     qreal m_pixelRatio;
+    qreal m_textureRotation;
     bool m_asynchronous;
 };
 

--- a/src/compositor/hwcimage.h
+++ b/src/compositor/hwcimage.h
@@ -1,0 +1,69 @@
+/***************************************************************************
+**
+** Copyright (C) 2015 Jolla Ltd.
+** Contact: Gunnar Sletta <gunnar.sletta@jollamobile.com>
+**
+** This file is part of lipstick.
+**
+** This library is free software; you can redistribute it and/or
+** modify it under the terms of the GNU Lesser General Public
+** License version 2.1 as published by the Free Software Foundation
+** and appearing in the file LICENSE.LGPL included in the packaging
+** of this file.
+**
+****************************************************************************/
+
+#ifndef HWCIMAGE_H
+#define HWCIMAGE_H
+
+#include <QUrl>
+#include <QImage>
+#include <QQuickItem>
+
+#include "lipstickglobal.h"
+
+class HwcImageNode;
+
+class LIPSTICK_EXPORT HwcImage : public QQuickItem
+{
+    Q_OBJECT
+    Q_PROPERTY(QUrl source READ source WRITE setSource NOTIFY sourceChanged)
+    Q_PROPERTY(Status status READ status NOTIFY statusChanged)
+    Q_PROPERTY(qreal darkness READ darkness WRITE setDarkness NOTIFY darknessChanged)
+
+    Q_ENUMS(Status)
+
+public:
+    enum Status { Null, Ready, Loading, Error };
+
+	HwcImage();
+	~HwcImage();
+
+	void setSource(const QUrl &url);
+	QUrl source() const { return m_source; }
+
+    void setDarkness(qreal darkness);
+    qreal darkness() const { return m_darkness; }
+
+    Status status() const { return m_status; }
+
+protected:
+	void updatePolish();
+
+	QSGNode *updatePaintNode(QSGNode *node, UpdatePaintNodeData *data);
+
+signals:
+    void sourceChanged();
+    void statusChanged();
+    void darknessChanged();
+
+private:
+    HwcImageNode *updateActualPaintNode(QSGNode *node);
+
+	QUrl m_source;
+    QImage m_image;
+    Status m_status;
+    qreal m_darkness;
+};
+
+#endif

--- a/src/compositor/hwcimage.h
+++ b/src/compositor/hwcimage.h
@@ -23,13 +23,20 @@
 #include "lipstickglobal.h"
 
 class HwcImageNode;
+class HwcImageLoadRequest;
+
+class QSGTexture;
 
 class LIPSTICK_EXPORT HwcImage : public QQuickItem
 {
     Q_OBJECT
     Q_PROPERTY(QUrl source READ source WRITE setSource NOTIFY sourceChanged)
     Q_PROPERTY(Status status READ status NOTIFY statusChanged)
-    Q_PROPERTY(qreal darkness READ darkness WRITE setDarkness NOTIFY darknessChanged)
+    Q_PROPERTY(QColor overlayColor READ overlayColor WRITE setOverlayColor NOTIFY overlayColorChanged)
+    Q_PROPERTY(qreal pixelRatio READ pixelRatio WRITE setPixelRatio NOTIFY pixelRatioChanged)
+    Q_PROPERTY(QSize textureSize READ textureSize WRITE setTextureSize NOTIFY textureSizeChanged)
+    Q_PROPERTY(QString effect READ effect WRITE setEffect NOTIFY effectChanged);
+    Q_PROPERTY(bool asynchronous READ isAsynchronous WRITE setAsynchronous WRITE asynchronousChanged)
 
     Q_ENUMS(Status)
 
@@ -42,28 +49,55 @@ public:
 	void setSource(const QUrl &url);
 	QUrl source() const { return m_source; }
 
-    void setDarkness(qreal darkness);
-    qreal darkness() const { return m_darkness; }
+    void setOverlayColor(const QColor &color);
+    QColor overlayColor() const { return m_overlayColor; }
 
     Status status() const { return m_status; }
 
+    void setTextureSize(const QSize &size);
+    QSize textureSize() const { return m_textureSize; }
+
+    void setEffect(const QString &effect);
+    QString effect() const { return m_effect; }
+
+    void setPixelRatio(qreal);
+    qreal pixelRatio() const { return m_pixelRatio; }
+
+    void setAsynchronous(bool is);
+    bool isAsynchronous() const;
+
 protected:
+    bool event(QEvent *event);
 	void updatePolish();
 
 	QSGNode *updatePaintNode(QSGNode *node, UpdatePaintNodeData *data);
 
 signals:
-    void sourceChanged();
-    void statusChanged();
-    void darknessChanged();
+    void sourceChanged(const QUrl &url);
+    void statusChanged(Status s);
+    void overlayColorChanged(const QColor &color);
+    void textureSizeChanged(const QSize &size);
+    void effectChanged(const QString &effect);
+    void pixelRatioChanged(qreal pr);
+    void asynchronousChanged(bool async);
 
 private:
+    friend class HwcImageLoadRequest;
+    void apply(HwcImageLoadRequest *);
     HwcImageNode *updateActualPaintNode(QSGNode *node);
+
+    QSGTexture *m_texture;
+
+    HwcImageLoadRequest *m_pendingRequest;
 
 	QUrl m_source;
     QImage m_image;
+    QSize m_textureSize;
+    QString m_effect;
     Status m_status;
-    qreal m_darkness;
+    QColor m_overlayColor;
+    qreal m_pixelRatio;
+    bool m_asynchronous;
 };
 
 #endif

--- a/src/compositor/hwcinterface.h
+++ b/src/compositor/hwcinterface.h
@@ -1,0 +1,156 @@
+// IMPORTANT!!!!
+//
+// This file is a copy from the one in the hwcomposer platform plugin
+// Make sure it is up to date, failing to do so will result in the
+// hardware compositor not working or at worst, binary incompatibility.
+
+/****************************************************************************
+**
+** Copyright (C) 2015 Jolla Ltd.
+** Contact: Gunnar Sletta <gunnar.sletta@jollamobile.com>
+**
+** This file is part of the hwcomposer plugin.
+**
+** GNU Lesser General Public License Usage
+** Alternatively, this file may be used under the terms of the GNU Lesser
+** General Public License version 2.1 as published by the Free Software
+** Foundation and appearing in the file LICENSE.LGPL included in the
+** packaging of this file.  Please review the following information to
+** ensure the GNU Lesser General Public License version 2.1 requirements
+** will be met: http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html.
+**
+** In addition, as a special exception, Digia gives you certain additional
+** rights.  These rights are described in the Digia Qt LGPL Exception
+** version 1.1, included in the file LGPL_EXCEPTION.txt in this package.
+**
+** GNU General Public License Usage
+** Alternatively, this file may be used under the terms of the GNU
+** General Public License version 3.0 as published by the Free Software
+** Foundation and appearing in the file LICENSE.GPL included in the
+** packaging of this file.  Please review the following information to
+** ensure the GNU General Public License version 3.0 requirements will be
+** met: http://www.gnu.org/copyleft/gpl.html.
+**
+****************************************************************************/
+
+#ifndef HWCINTERFACE_H
+#define HWCINTERFACE_H
+
+//
+// IMPORTANT!!!
+//
+// If you make any changes to this file, make sure that you also increment the
+// version of the native resource "hwcinterface" in the platform integration.
+// Applications that ask for this resource will be binary compatible and crash
+// unless they get the exact version they are asking for.
+//
+// You should also update any applications you know of that makes use of this
+// interface after changing it.
+//
+
+#define HWC_INTERFACE_STRING "hwcinterface v0.1"
+
+namespace HwcInterface
+{
+
+
+    struct Layer
+    {
+        // The hardware buffer handle, typically a buffer_handle_t
+        void *handle;
+
+        // The target rect, in pixels
+        int tx, ty, tw, th;
+
+        // The source rect, in pixels.
+        int sx, sy, sw, sh;
+
+        // Set to true after the layer list has become active. Indicates
+        // that the layer will be handled by the hardware compositor.
+        // In a list of 4 layers where only 2 layers are supported, the back-most
+        // two layers will be accepted. This allows for composition of the front-most
+        // two in the EGL surface.
+        //
+        // This value will be set by the hardware compositor when accepted.
+        // Changing it from the client side will result in undefined behavior.
+        uint accepted: 1;
+
+        // we don't have HWCs that support opacity or color layers, so ignore these for now
+        // Also, sailfish does orientation changes by rendering rotated, so 90 degree flipping
+        // is not required for now. Lets keep it as simple as possible...
+
+        // for future use...
+        uint reserved : 31;
+    };
+
+    struct LayerList
+    {
+        // Set by the caller to indicate that EGL rendering is in use
+        // and that the compositor should reserve space for that in the
+        // internal render list.
+        //
+        // This value can be changed by the Compositor to true if layers are not
+        // accepted and must be composited in EGL.
+        uint eglRenderingEnabled : 1;
+
+        // for future use...
+        uint reserved : 31;
+
+        /* The number of layers in 'layers'
+         */
+        int layerCount;
+
+        // The actual layers, packed at the end of this struct..
+        Layer layers[0];
+    };
+
+    class Compositor
+    {
+    public:
+        virtual ~Compositor() {}
+
+        /* Can be called from any thread, will schedule a prepare() call on
+           HWC to check how feasible it is to perform the composition of these
+           layers. Each call MUST contain a uniqure pointer.
+
+           Compositor takes ownership of the LayerList and will call the
+           'ReleaseLayerListCallback' once the list is no longer in use.
+
+           The LayerList should be considered an invalid pointer until the
+           time it reappears as 'acceptedLayerList'. From this moment on,
+           until the next scheduleLayerList is called, the user can update
+           buffer handles only.
+
+           If a scheduled layer list is not accepted at all, for instance
+           because all buffers try to use an unsupported feature, the
+           'scheduledLayerList' will never become accepted.
+         */
+        virtual void scheduleLayerList(LayerList *list) = 0;
+
+        /* Will be called by the EGL rendering thread. By default this will be 0.
+           After a call to scheduleLayerList, the HWC thread will make a prepare()
+           call to check the feasibility of compositing the layers. After this
+           call has completed, the layer list will be accepted.
+
+           An accepted layer list is only actually taken into use once a call
+           to swapLayerList with this specific layer list is called.
+          */
+        virtual const LayerList *acceptedLayerList() const = 0;
+
+        // Swaps the layer list.
+        // It is a fatal error if the list is different from 'acceptedLayerList'.
+        // It is a fatal error if the list contains changes other than updates
+        // to buffer handles.
+        virtual void swapLayerList(LayerList *list) = 0;
+
+        typedef void (*ReleaseLayerListCallback)(LayerList *list);
+        virtual void setReleaseLayerListCallback(ReleaseLayerListCallback callback) = 0;
+
+        typedef void (*BufferAvailableCallback)(void *handle, void *data);
+        virtual void setBufferAvailableCallback(BufferAvailableCallback, void *) = 0;
+    };
+
+}; // end namespace
+
+#endif // HWCINTERFACE_H
+

--- a/src/compositor/hwcrenderstage.cpp
+++ b/src/compositor/hwcrenderstage.cpp
@@ -1,0 +1,354 @@
+/***************************************************************************
+**
+** Copyright (C) 2015 Jolla Ltd.
+** Contact: Gunnar Sletta <gunnar.sletta@jollamobile.com>
+**
+** This file is part of lipstick.
+**
+** This library is free software; you can redistribute it and/or
+** modify it under the terms of the GNU Lesser General Public
+** License version 2.1 as published by the Free Software Foundation
+** and appearing in the file LICENSE.LGPL included in the packaging
+** of this file.
+**
+****************************************************************************/
+
+#include "hwcrenderstage.h"
+#include "hwcinterface.h"
+
+#include "lipstickcompositor.h"
+
+#include <private/qguiapplication_p.h>
+#include <qpa/qplatformintegration.h>
+#include <qpa/qplatformnativeinterface.h>
+
+#include <qsgnode.h>
+#include <qsgtexturematerial.h>
+
+#include <EGL/egl.h>
+
+Q_LOGGING_CATEGORY(LIPSTICK_LOG_HWC, "qt.lipstick.hwc")
+
+const QEvent::Type HWC_BufferRelease = (QEvent::Type) (QEvent::User + 1);
+
+class HwcBufferReleaseEvent : public QEvent
+{
+public:
+    HwcBufferReleaseEvent(void *b) : QEvent(HWC_BufferRelease), buffer(b) { }
+    void *buffer;
+};
+
+// Any number above QSGNode::RenderNode will strictly do..
+#define QSG_HWC_NODE_TYPE ((QSGNode::NodeType) 1000)
+
+HwcNode::HwcNode()
+    : QSGNode(QSG_HWC_NODE_TYPE)
+    , m_buffer_handle(0)
+    , m_x(0)
+    , m_y(0)
+    , m_blocked(false)
+{
+    qsgnode_set_description(this, QStringLiteral("hwcnode"));
+}
+
+void HwcNode::update(void *handle)
+{
+    m_buffer_handle = handle;
+}
+
+void HwcNode::setBlocked(bool blocked)
+{
+    if (m_blocked != blocked) {
+        m_blocked = blocked;
+        markDirty(DirtySubtreeBlocked);
+    }
+}
+
+QRect HwcNode::bounds() const
+{
+    Q_ASSERT(firstChild());
+    Q_ASSERT(firstChild()->type() == QSGNode::GeometryNodeType);
+    QSGGeometry *g = static_cast<QSGGeometryNode *>(firstChild())->geometry();
+    QSGGeometry::TexturedPoint2D *v = g->vertexDataAsTexturedPoint2D();
+    float x1 = v[0].x;        // v0--v2
+    float y1 = v[0].y;        // |  / |
+    float x2 = v[2].x;        // | /  |
+    float y2 = v[1].y;        // v1--v3
+    return QRect(x1, y1, x2-x1, y2-y1);
+}
+
+#ifndef QT_NO_DEBUG
+static inline bool hwc_renderstage_isRect(QSGGeometry::TexturedPoint2D *v)
+{
+    return v[0].x == v[1].x && v[2].x == v[3].x
+           && v[0].y == v[2].y && v[1].y == v[3].y
+           && v[0].tx == v[1].tx && v[2].tx == v[3].tx
+           && v[0].ty == v[2].ty && v[1].ty == v[3].ty;
+}
+
+static inline void hwc_renderstage_check_node(QSGNode *node)
+{
+    static const QSGMaterialType *opaqueTextureType = QSGOpaqueTextureMaterial().type();
+    static const QSGMaterialType *alphaTextureType = QSGTextureMaterial().type();
+    static const QSGGeometry::Attribute *attributes = QSGGeometry::defaultAttributes_TexturedPoint2D().attributes;
+
+    Q_ASSERT(node->type() == QSG_HWC_NODE_TYPE);
+
+    Q_ASSERT(node->firstChild());
+    Q_ASSERT(node->firstChild()->type() == QSGNode::GeometryNodeType);
+    QSGGeometryNode *gn = static_cast<QSGGeometryNode *>(node->firstChild());
+
+    QSGGeometry *g = gn->geometry();
+    Q_ASSERT(g->vertexCount() == 4);
+    Q_ASSERT(g->indexCount() == 0);
+    Q_ASSERT(g->attributes() == attributes);
+    Q_ASSERT(hwc_renderstage_isRect(g->vertexDataAsTexturedPoint2D()));
+    Q_ASSERT(gn->opaqueMaterial() && gn->opaqueMaterial()->type() == opaqueTextureType);
+    Q_ASSERT(gn->material()->type() == alphaTextureType);
+}
+#else
+#define hwc_renderstage_check_node(node)
+#endif
+
+bool HwcRenderStage::m_hwcEnabled = false;
+
+void HwcRenderStage::initialize(LipstickCompositor *lipstick)
+{
+    static bool enabled = qgetenv("LIPSTICK_HARDWARE_COMPOSITOR").toInt() != 0;
+    QPlatformNativeInterface *iface = QGuiApplicationPrivate::platform_integration->nativeInterface();
+    if (!enabled) {
+        qDebug() << "Hardware Compositor support is disabled";
+        return;
+    }
+    Q_ASSERT(iface);
+    EGLDisplay eglDisplay = iface->nativeResourceForIntegration("egldisplay");
+    Q_ASSERT(eglDisplay);
+
+    qCDebug(LIPSTICK_LOG_HWC, "EGL Extensions: %s", eglQueryString(eglDisplay, EGL_EXTENSIONS));
+
+    void *compositor = iface->nativeResourceForIntegration(HWC_INTERFACE_STRING);
+    if (!compositor) {
+        qDebug("Hardware Compositor is not enabled, missing native resource named: '%s'", HWC_INTERFACE_STRING);
+        return;
+    }
+    Q_ASSERT(compositor);
+    QQuickWindowPrivate::get(lipstick)->customRenderStage = new HwcRenderStage(lipstick, compositor);
+    qDebug() << "Hardware Compositor support is enabled";
+    m_hwcEnabled = true;
+}
+
+static HwcInterface::LayerList *hwc_renderstage_create_list(const QVector<HwcNode *> &nodes)
+{
+    int size = sizeof(HwcInterface::LayerList) + sizeof(HwcInterface::Layer) * nodes.size();
+    HwcInterface::LayerList *list = (HwcInterface::LayerList *) malloc(size);
+    memset(list, 0, size);
+    list->layerCount = nodes.size();
+    for (int i=0; i<nodes.size(); ++i) {
+        HwcInterface::Layer &l = list->layers[i];
+        HwcNode *n = nodes.at(i);
+        QRect r = n->bounds();
+        l.sx = 0;
+        l.sy = 0;
+        l.tx = r.x() + n->x();
+        l.ty = r.y() + n->y();
+        l.sw = l.tw = r.width();
+        l.sh = l.th = r.height();
+        l.handle = n->handle();
+    }
+    return list;
+}
+
+static void hwc_renderstage_buffer_available(void *, void *)
+{
+    // ignore for now.. We're only using this for static bg images atm..
+}
+
+static void hwc_renderstage_delete_list(HwcInterface::LayerList *list)
+{
+    free(list);
+}
+
+static void hwc_renderstage_dump_layerlist(HwcInterface::LayerList *list)
+{
+    qCDebug(LIPSTICK_LOG_HWC, " - eglRenderingEnabled: %d", list->eglRenderingEnabled);
+    for (int i=0; i<list->layerCount; ++i) {
+        const HwcInterface::Layer &l = list->layers[i];
+        qCDebug(LIPSTICK_LOG_HWC, " - layer %d: target=(%d,%d, %dx%d), source=(%d,%d, %dx%d) handle=%p, accepted=%d",
+                i,
+                l.tx, l.ty, l.tw, l.th,
+                l.sx, l.sy, l.sw, l.sh,
+                l.handle, l.accepted);
+    }
+}
+
+
+HwcRenderStage::HwcRenderStage(LipstickCompositor *lipstick, void *compositorHandle)
+    : m_lipstick(lipstick)
+    , m_window(lipstick)
+    , m_hwc(reinterpret_cast<HwcInterface::Compositor *>(compositorHandle))
+    , m_scheduledLayerList(false)
+{
+    m_hwc->setReleaseLayerListCallback(hwc_renderstage_delete_list);
+    m_hwc->setBufferAvailableCallback(hwc_renderstage_buffer_available, this);
+}
+
+HwcRenderStage::~HwcRenderStage()
+{
+}
+
+
+bool HwcRenderStage::render()
+{
+    QQuickWindowPrivate *d = QQuickWindowPrivate::get(m_window);
+    if (d->renderer && d->renderer->rootNode()) {
+        QSGRootNode *rootNode = d->renderer->rootNode();
+        m_nodesToTry.clear();
+        bool layersOnly = checkSceneGraph(rootNode);
+
+        if (m_nodesToTry.size()) {
+
+            // ### Also check for geometry changes here...
+            if (m_nodesInList != m_nodesToTry) {
+                m_layerList = hwc_renderstage_create_list(m_nodesToTry);
+                m_layerList->eglRenderingEnabled = !layersOnly;
+                if (LIPSTICK_LOG_HWC().isDebugEnabled()) {
+                    qDebug() << endl << endl << endl << endl << endl << endl << endl;
+                    qCDebug(LIPSTICK_LOG_HWC, "HwcRenderStage::render(), scheduling new layer list (using GL)");
+                    hwc_renderstage_dump_layerlist(m_layerList);
+                }
+                foreach (HwcNode *n, m_nodesInList)
+                    n->setBlocked(false);
+                m_nodesInList = m_nodesToTry;
+                m_scheduledLayerList = true;
+                m_hwc->scheduleLayerList(m_layerList);
+            }
+
+            if (m_layerList && m_layerList == m_hwc->acceptedLayerList()) {
+                if (m_scheduledLayerList) {
+                    // newly accepted, toggle blocking in the scene graph...
+                    if (LIPSTICK_LOG_HWC().isDebugEnabled()) {
+                        qCDebug(LIPSTICK_LOG_HWC, "HwcRenderStage::render(), layer list was accepted (using HWC%s)",
+                                m_layerList->eglRenderingEnabled ? "+GL" : "");
+                        hwc_renderstage_dump_layerlist(m_layerList);
+                    }
+                    m_scheduledLayerList = false;
+                    for (int i=0; i<m_nodesToTry.size(); ++i) {
+                        HwcNode *n = m_nodesInList[i];
+                        n->setBlocked(m_layerList->layers[i].accepted);
+                    }
+                }
+
+                for (int i=0; i<m_nodesInList.size(); ++i) {
+                    HwcInterface::Layer &l = m_layerList->layers[i];
+                    if (l.accepted) {
+                        l.handle = m_nodesInList.at(i)->handle();
+                    } else {
+                        l.handle = 0;
+                    }
+                }
+
+                if (!m_layerList->eglRenderingEnabled) {
+                    // Our list is the only content, so skip SG render stage.
+                    return true;
+                }
+            }
+
+        } else {
+            if (LIPSTICK_LOG_HWC().isDebugEnabled()) {
+                static bool once = false;
+                if (m_layerList || !once) {
+                    qCDebug(LIPSTICK_LOG_HWC, "HwcRenderStage::render(), no layers (using GL)");
+                    once = true;
+                }
+            }
+            foreach (HwcNode *n, m_nodesInList)
+                n->setBlocked(false);
+            m_nodesInList.clear();
+            m_layerList = 0;
+        }
+    }
+    return false;
+}
+
+bool HwcRenderStage::swap()
+{
+    if (m_layerList && m_layerList == m_hwc->acceptedLayerList()) {
+        m_hwc->swapLayerList(m_layerList);
+        return true;
+    }
+    return false;
+}
+
+
+struct QMatrix4x4_Accessor
+{
+    float m[4][4];
+    int flagBits;
+    static bool isTranslate(const QMatrix4x4 &m) { return ((const QMatrix4x4_Accessor &) m).flagBits <= 0x1; }
+};
+
+/*
+    Iterates over the scene graph in a left-to-right depth first manner,
+    (back-to-front in visual terms). When it finds composer compatible
+    nodes, these are added to the composition list.
+
+    When a node is hit that is not hwcomposer compatible, the function starts
+    returning false.
+
+    Returns true if all content in the scene graph could be rendered by the
+    hardware composer.
+
+    Returns false if there exists content in the graph that must be rendered
+    using EGL.
+
+    The nodes to compose (if any) will be listed in m_nodesToTry.
+ */
+
+bool HwcRenderStage::checkSceneGraph(QSGNode *node)
+{
+    if (node->type() == QSG_HWC_NODE_TYPE) {
+
+        // get x/y offset on screen and check for transformations...
+        QQuickWindowPrivate *d = QQuickWindowPrivate::get(m_window);
+        QSGRootNode *root = d->renderer->rootNode();
+        QSGNode *p = node->parent();
+        float x=0, y=0;
+        while (p != root) {
+            if (p->type() == QSGNode::TransformNodeType) {
+                QSGTransformNode *tn = static_cast<QSGTransformNode *>(p);
+                const QMatrix4x4 &m = tn->matrix();
+                if (!QMatrix4x4_Accessor::isTranslate(m))
+                    return true;
+                x += m(0, 3);
+                y += m(1, 3);
+            }
+            p = p->parent();
+        }
+
+        HwcNode *hwcNode = static_cast<HwcNode *>(node);
+        hwc_renderstage_check_node(hwcNode);
+        hwcNode->setPos(x, y);
+        m_nodesToTry << hwcNode;
+
+        // HwcNodes have only the one child, which is whatever node that holds
+        // the buffer, so we don't want to traverse downwards from here.
+        return true;
+
+    } else if (node->isSubtreeBlocked()) {
+        return true;
+
+    } else if (node->type() == QSGNode::GeometryNodeType
+               || (node->type() == QSGNode::OpacityNodeType && static_cast<QSGOpacityNode *>(node)->opacity() < 1.0f)
+               || node->type() == QSGNode::ClipNodeType
+               || node->type() == QSGNode::RenderNodeType) {
+        return false;
+    }
+
+    for (QSGNode *child = node->firstChild(); child; child = child->nextSibling()) {
+        if (!checkSceneGraph(child))
+            return false;
+    }
+
+    return true;
+}
+

--- a/src/compositor/hwcrenderstage.h
+++ b/src/compositor/hwcrenderstage.h
@@ -34,7 +34,7 @@ public:
 
     QRect bounds() const;
 
-    void update(void *handle);
+    void update(QSGGeometryNode *node, void *handle);
 
     void *handle() const { return m_buffer_handle; }
     bool isSubtreeBlocked() const { return m_blocked; }
@@ -47,7 +47,10 @@ public:
         m_y = y;
     }
 
+    QSGGeometryNode *contentNode() const { return m_contentNode; }
+
 private:
+    QSGGeometryNode *m_contentNode;
     void *m_buffer_handle;
     float m_x, m_y;
     bool m_blocked;

--- a/src/compositor/hwcrenderstage.h
+++ b/src/compositor/hwcrenderstage.h
@@ -1,0 +1,87 @@
+/***************************************************************************
+**
+** Copyright (C) 2015 Jolla Ltd.
+** Contact: Gunnar Sletta <gunnar.sletta@jollamobile.com>
+**
+** This file is part of lipstick.
+**
+** This library is free software; you can redistribute it and/or
+** modify it under the terms of the GNU Lesser General Public
+** License version 2.1 as published by the Free Software Foundation
+** and appearing in the file LICENSE.LGPL included in the packaging
+** of this file.
+**
+****************************************************************************/
+
+#ifndef HWCRENDERSTAGE
+#define HWCRENDERSTAGE
+
+#include <private/qquickwindow_p.h>
+
+Q_DECLARE_LOGGING_CATEGORY(LIPSTICK_LOG_HWC)
+
+class LipstickCompositor;
+
+namespace HwcInterface {
+    class Compositor;
+    class LayerList;
+}
+
+class HwcNode : public QSGNode
+{
+public:
+    HwcNode();
+
+    QRect bounds() const;
+
+    void update(void *handle);
+
+    void *handle() const { return m_buffer_handle; }
+    bool isSubtreeBlocked() const { return m_blocked; }
+    void setBlocked(bool b);
+
+    float x() const { return m_x; }
+    float y() const { return m_y; }
+    void setPos(float x, float y) {
+        m_x = x;
+        m_y = y;
+    }
+
+private:
+    void *m_buffer_handle;
+    float m_x, m_y;
+    bool m_blocked;
+};
+
+class HwcRenderStage : public QObject, public QQuickCustomRenderStage
+{
+    Q_OBJECT
+
+public:
+    HwcRenderStage(LipstickCompositor *lipstick, void *hwcHandle);
+    ~HwcRenderStage();
+    bool render() Q_DECL_OVERRIDE;
+    bool swap() Q_DECL_OVERRIDE;
+
+    static void initialize(LipstickCompositor *lipstick);
+    static bool isHwcEnabled() { return m_hwcEnabled; }
+
+private:
+    bool checkSceneGraph(QSGNode *node);
+
+    LipstickCompositor *m_lipstick;
+    QQuickWindow *m_window;
+
+    HwcInterface::Compositor *m_hwc;
+
+    QVector<HwcNode *> m_nodesInList;
+    QVector<HwcNode *> m_nodesToTry;
+
+    HwcInterface::LayerList *m_layerList;
+
+    bool m_scheduledLayerList;
+
+    static bool m_hwcEnabled;
+};
+
+#endif // HWCRENDERSTAGE

--- a/src/compositor/lipstickcompositor.cpp
+++ b/src/compositor/lipstickcompositor.cpp
@@ -33,6 +33,9 @@
 #include "lipstickrecorder.h"
 #include <qpa/qwindowsysteminterface.h>
 #include "alienmanager/alienmanager.h"
+#include "hwcrenderstage.h"
+#include <private/qguiapplication_p.h>
+#include <QtGui/qpa/qplatformintegration.h>
 
 LipstickCompositor *LipstickCompositor::m_instance = 0;
 
@@ -40,7 +43,7 @@ LipstickCompositor::LipstickCompositor()
 : QWaylandQuickCompositor(this), m_totalWindowCount(0), m_nextWindowId(1), m_homeActive(true), m_shaderEffect(0),
   m_fullscreenSurface(0), m_directRenderingActive(false), m_topmostWindowId(0), m_screenOrientation(Qt::PrimaryOrientation), m_sensorOrientation(Qt::PrimaryOrientation), m_displayState(new MeeGo::QmDisplayState(this)), m_retainedSelection(0), m_previousDisplayState(m_displayState->get()), m_updatesEnabled(true), m_onUpdatesDisabledUnfocusedWindowId(0)
 {
-    setColor(Qt::black);
+    setColor(Qt::transparent);
     setRetainedSelectionEnabled(true);
     addDefaultShell();
 
@@ -93,6 +96,8 @@ LipstickCompositor::LipstickCompositor()
     m_recorder = new LipstickRecorderManager;
     addGlobalInterface(m_recorder);
     addGlobalInterface(new AlienManagerGlobal);
+
+    HwcRenderStage::initialize(this);
 }
 
 LipstickCompositor::~LipstickCompositor()
@@ -297,6 +302,8 @@ void LipstickCompositor::setFullscreenSurface(QWaylandSurface *surface)
 {
     if (surface == m_fullscreenSurface)
         return;
+
+    qDebug() << "Fullscreen Surface is: " << surface;
 
     // Prevent flicker when returning to composited mode
     if (!surface && m_fullscreenSurface) {

--- a/src/compositor/lipstickcompositorwindow.cpp
+++ b/src/compositor/lipstickcompositorwindow.cpp
@@ -365,3 +365,4 @@ void LipstickCompositorWindow::connectSurfaceSignals()
         m_surfaceConnections << connect(surface(), &QWaylandSurface::configure, this, &LipstickCompositorWindow::committed);
     }
 }
+


### PR DESCRIPTION
On the rendering thread in lipstick, we install a custom scene graph
rendering stage. In this stage, we look through the scene graph for
hardware compatible nodes and put these into their own block.

We're currently only supporting in-process images (for background
images) without rotation (for now) and no scaling. The custom render
stage will look at the transform of these images and decide if it can
be sent to the hwc or not.

We can talk to the hwc using an abstraction API called HwcInterface
which we can query from the QPA plugin. The API is located in
'hwcinterface.h' and is a direct copy of the same file inside
the QPA plugin. It has been done like this to have some API
while keeping this out of the public API. There is a version
name string to prevent mismatches between the plugin and the
hwc.

Once we've identified buffers to draw using the hwc we create a
HwcInterface::LayerList which contains the buffer handles. The layer
list can also include GL rendering which will stack on top. We
schedule this to the hwc and will be notified some time later if it is
accepted or not. Until it is, we render all GL as normal. Once
accepted, we switch to swapping the layer list instead of using
eglSwapBuffers().

The feature is enabled by setting LIPSTICK_HARDWARE_COMPOSITOR=1
in the environment.