### PR TITLE
[lipstick] Allow other event filters to run before touch interception.

### DIFF
--- a/src/compositor/lipstickcompositorwindow.cpp
+++ b/src/compositor/lipstickcompositorwindow.cpp
@@ -193,7 +193,6 @@ bool LipstickCompositorWindow::eventFilter(QObject *obj, QEvent *event)
         }
         case QEvent::TouchEnd: // Intentional fall through...
         case QEvent::TouchCancel:
-            obj->removeEventFilter(this);
             m_interceptingTouch = false;
         default:
             break;
@@ -288,13 +287,25 @@ void LipstickCompositorWindow::touchEvent(QTouchEvent *event)
             // On TouchBegin, start intercepting
             if (event->isAccepted() && !m_interceptingTouch) {
                 m_interceptingTouch = true;
-                window()->installEventFilter(this);
             }
         }
 #endif
     } else {
         event->ignore();
     }
+}
+
+void LipstickCompositorWindow::itemChange(QQuickItem::ItemChange change, const QQuickItem::ItemChangeData &data)
+{
+    if (change == ItemSceneChange) {
+        if (window())
+            window()->removeEventFilter(this);
+
+        if (data.window)
+            data.window->installEventFilter(this);
+    }
+
+    QWaylandSurfaceItem::itemChange(change, data);
 }
 
 void LipstickCompositorWindow::handleTouchEvent(QTouchEvent *event)
@@ -337,7 +348,6 @@ void LipstickCompositorWindow::handleTouchCancel()
         inputDevice->sendTouchCancelEvent();
         inputDevice->setMouseFocus(0, QPointF());
     }
-    window()->removeEventFilter(this);
     m_interceptingTouch = false;
 }
 

--- a/src/compositor/lipstickcompositorwindow.h
+++ b/src/compositor/lipstickcompositorwindow.h
@@ -65,6 +65,7 @@ protected:
     virtual void mouseReleaseEvent(QMouseEvent *event);
     virtual void wheelEvent(QWheelEvent *event);
     virtual void touchEvent(QTouchEvent *event);
+    virtual void itemChange(QQuickItem::ItemChange change, const QQuickItem::ItemChangeData &data);
 
 signals:
     void userDataChanged();


### PR DESCRIPTION
LipstickCompositorWindow was installing an event filter when a
TouchBegin event was received. This resulted in it being the first
filter to be run for subsequent events. Instead install and remove
the interception filter on scene change. This ensures that other
filters have a chance to see the events.