### PR TITLE
[lipstick] Extend notifications with 'origin' property

### DIFF
--- a/src/notifications/lipsticknotification.cpp
+++ b/src/notifications/lipsticknotification.cpp
@@ -291,6 +291,11 @@ QVariantList LipstickNotification::remoteActions() const
     return rv;
 }
 
+QString LipstickNotification::origin() const
+{
+    return hints_.value(NotificationManager::HINT_ORIGIN).toString();
+}
+
 QDBusArgument &operator<<(QDBusArgument &argument, const LipstickNotification &notification)
 {
     argument.beginStructure();

--- a/src/notifications/lipsticknotification.h
+++ b/src/notifications/lipsticknotification.h
@@ -47,6 +47,7 @@ class LIPSTICK_EXPORT LipstickNotification : public QObject
     Q_PROPERTY(QString category READ category NOTIFY categoryChanged)
     Q_PROPERTY(bool userRemovable READ isUserRemovable NOTIFY userRemovableChanged)
     Q_PROPERTY(QVariantList remoteActions READ remoteActions CONSTANT)
+    Q_PROPERTY(QString origin READ origin CONSTANT)
 
 public:
     /*!
@@ -149,7 +150,11 @@ public:
     //! Returns true if the notification has been hidden to prevent further display
     bool hidden() const;
 
+    //! Returns the remote actions invokable by the notification
     QVariantList remoteActions() const;
+
+    //! Returns an indicator for the origin of the notification
+    QString origin() const;
 
     //! \internal
     /*!

--- a/src/notifications/notificationmanager.cpp
+++ b/src/notifications/notificationmanager.cpp
@@ -68,6 +68,7 @@ const char *NotificationManager::HINT_FEEDBACK = "x-nemo-feedback";
 const char *NotificationManager::HINT_HIDDEN = "x-nemo-hidden";
 const char *NotificationManager::HINT_DISPLAY_ON = "x-nemo-display-on";
 const char *NotificationManager::HINT_LED_DISABLED_WITHOUT_BODY_AND_SUMMARY = "x-nemo-led-disabled-without-body-and-summary";
+const char *NotificationManager::HINT_ORIGIN = "x-nemo-origin";
 
 NotificationManager *NotificationManager::instance_ = 0;
 
@@ -133,6 +134,7 @@ QStringList NotificationManager::GetCapabilities()
                          << HINT_PREVIEW_SUMMARY
                          << "x-nemo-remote-actions"
                          << HINT_USER_REMOVABLE
+                         << HINT_ORIGIN
                          << "x-nemo-get-notifications";
 }
 

--- a/src/notifications/notificationmanager.h
+++ b/src/notifications/notificationmanager.h
@@ -109,6 +109,9 @@ public:
     //! Nemo hint: Whether to disable LED feedbacks when there is no body and summary
     static const char *HINT_LED_DISABLED_WITHOUT_BODY_AND_SUMMARY;
 
+    //! Nemo hint: Indicates the origin of the notification
+    static const char *HINT_ORIGIN;
+
     //! Notifation closing reasons used in the NotificationClosed signal
     enum NotificationClosedReason {
         //! The notification expired.

--- a/tests/stubs/notificationmanager_stub.h
+++ b/tests/stubs/notificationmanager_stub.h
@@ -165,6 +165,7 @@ const char *NotificationManager::HINT_REMOTE_ACTION_ICON_PREFIX = "x-nemo-remote
 const char *NotificationManager::HINT_HIDDEN = "x-nemo-hidden";
 const char *NotificationManager::HINT_USER_REMOVABLE = "x-nemo-user-removable";
 const char *NotificationManager::HINT_LED_DISABLED_WITHOUT_BODY_AND_SUMMARY = "x-nemo-led-disabled-without-body-and-summary";
+const char *NotificationManager::HINT_ORIGIN = "x-nemo-origin";
 
 NotificationManager *NotificationManager::instance_ = 0;
 NotificationManager * NotificationManager::instance() {

--- a/tests/ut_notificationfeedbackplayer/ut_notificationfeedbackplayer.cpp
+++ b/tests/ut_notificationfeedbackplayer/ut_notificationfeedbackplayer.cpp
@@ -36,6 +36,7 @@ const char *NotificationManager::HINT_FEEDBACK = "x-nemo-feedback";
 const char *NotificationManager::HINT_USER_REMOVABLE = "x-nemo-user-removable";
 const char *NotificationManager::HINT_DISPLAY_ON = "x-nemo-display-on";
 const char *NotificationManager::HINT_LED_DISABLED_WITHOUT_BODY_AND_SUMMARY = "x-nemo-led-disabled-without-body-and-summary";
+const char *NotificationManager::HINT_ORIGIN = "x-nemo-origin";
 
 NotificationManager::NotificationManager(QObject *parent) : QObject(parent)
 {

--- a/tests/ut_notificationmanager/ut_notificationmanager.cpp
+++ b/tests/ut_notificationmanager/ut_notificationmanager.cpp
@@ -456,7 +456,7 @@ void Ut_NotificationManager::testCapabilities()
 {
     // Check the supported capabilities includes all the Nemo hints
     QStringList capabilities = NotificationManager::instance()->GetCapabilities();
-    QCOMPARE(capabilities.count(), 11);
+    QCOMPARE(capabilities.count(), 12);
     QCOMPARE((bool)capabilities.contains("body"), true);
     QCOMPARE((bool)capabilities.contains("actions"), true);
     QCOMPARE((bool)capabilities.contains(NotificationManager::HINT_ICON), true);
@@ -468,6 +468,7 @@ void Ut_NotificationManager::testCapabilities()
     QCOMPARE((bool)capabilities.contains("x-nemo-remote-actions"), true);
     QCOMPARE((bool)capabilities.contains(NotificationManager::HINT_USER_REMOVABLE), true);
     QCOMPARE((bool)capabilities.contains("x-nemo-get-notifications"), true);
+    QCOMPARE((bool)capabilities.contains(NotificationManager::HINT_ORIGIN), true);
 }
 
 void Ut_NotificationManager::testAddingNotification()

--- a/tests/ut_notificationpreviewpresenter/ut_notificationpreviewpresenter.cpp
+++ b/tests/ut_notificationpreviewpresenter/ut_notificationpreviewpresenter.cpp
@@ -109,6 +109,7 @@ const char *NotificationManager::HINT_REMOTE_ACTION_PREFIX = "x-nemo-remote-acti
 const char *NotificationManager::HINT_REMOTE_ACTION_ICON_PREFIX = "x-nemo-remote-action-icon-";
 const char *NotificationManager::HINT_HIDDEN = "x-nemo-hidden";
 const char *NotificationManager::HINT_USER_REMOVABLE = "x-nemo-user-removable";
+const char *NotificationManager::HINT_ORIGIN = "x-nemo-origin";
 
 NotificationManager::NotificationManager(QObject *parent) : QObject(parent)
 {


### PR DESCRIPTION
This property allows clients to indicate the origin of a notification
to the manager.  The interpretation of this property is left to
the notification manager.