### PR TITLE
Trigger notification expiry

### DIFF
--- a/src/notifications/notificationpreviewpresenter.cpp
+++ b/src/notifications/notificationpreviewpresenter.cpp
@@ -74,7 +74,7 @@ void NotificationPreviewPresenter::showNextNotification()
 
         if (locks->getState(MeeGo::QmLocks::TouchAndKeyboard) == MeeGo::QmLocks::Locked && displayState->get() == MeeGo::QmDisplayState::Off) {
             // Screen locked and off: don't show the notification but just remove it from the queue
-            emit notificationPresented(notification->property("id").toUInt());
+            emit notificationPresented(notification->replacesId());
 
             setCurrentNotification(0);
 
@@ -85,7 +85,7 @@ void NotificationPreviewPresenter::showNextNotification()
                 window->show();
             }
 
-            emit notificationPresented(notification->property("id").toUInt());
+            emit notificationPresented(notification->replacesId());
 
             setCurrentNotification(notification);
         }
@@ -102,7 +102,6 @@ void NotificationPreviewPresenter::updateNotification(uint id)
     LipstickNotification *notification = NotificationManager::instance()->notification(id);
 
     if (notification != 0) {
-        notification->setProperty("id", id);
         if (notificationShouldBeShown(notification)) {
             // Add the notification to the queue if not already there or the current notification
             if (currentNotification != notification && !notificationQueue.contains(notification)) {
@@ -181,7 +180,7 @@ void NotificationPreviewPresenter::setCurrentNotification(LipstickNotification *
 {
     if (currentNotification != notification) {
         if (currentNotification) {
-            NotificationManager::instance()->MarkNotificationDisplayed(currentNotification->property("id").toUInt());
+            NotificationManager::instance()->MarkNotificationDisplayed(currentNotification->replacesId());
         }
 
         currentNotification = notification;

--- a/src/notifications/notificationpreviewpresenter.cpp
+++ b/src/notifications/notificationpreviewpresenter.cpp
@@ -119,8 +119,8 @@ void NotificationPreviewPresenter::updateNotification(uint id)
 
             removeNotification(id, true);
 
-            if (currentNotification != notification && notification->urgency() >= 2) {
-                NotificationManager::instance()->CloseNotification(id);
+            if (currentNotification != notification) {
+                NotificationManager::instance()->MarkNotificationDisplayed(id);
             }
         }
     }
@@ -180,8 +180,8 @@ bool NotificationPreviewPresenter::notificationShouldBeShown(LipstickNotificatio
 void NotificationPreviewPresenter::setCurrentNotification(LipstickNotification *notification)
 {
     if (currentNotification != notification) {
-        if (currentNotification != 0 && currentNotification->urgency() >= 2) {
-            NotificationManager::instance()->CloseNotification(currentNotification->property("id").toUInt());
+        if (currentNotification) {
+            NotificationManager::instance()->MarkNotificationDisplayed(currentNotification->property("id").toUInt());
         }
 
         currentNotification = notification;

--- a/tests/ut_notificationfeedbackplayer/ut_notificationfeedbackplayer.cpp
+++ b/tests/ut_notificationfeedbackplayer/ut_notificationfeedbackplayer.cpp
@@ -96,14 +96,13 @@ QList<uint> NotificationManager::notificationIds() const
 
 LipstickNotification *createNotification(uint id, int urgency = 0, QVariant priority = QVariant())
 {
-    LipstickNotification *notification = new LipstickNotification;
     QVariantHash hints;
     hints.insert(NotificationManager::HINT_FEEDBACK, "feedback");
     hints.insert(NotificationManager::HINT_URGENCY, urgency);
     if (priority.isValid()) {
         hints.insert(NotificationManager::HINT_PRIORITY, priority);
     }
-    notification->setHints(hints);
+    LipstickNotification *notification = new LipstickNotification("ut_notificationfeedbackplayer", id, "", "", "", QStringList(), hints, -1);
     notificationManagerNotification.insert(id, notification);
     return notification;
 }
@@ -299,19 +298,14 @@ void Ut_NotificationFeedbackPlayer::testLEDDisabledWhenNoSummaryAndBody()
     QFETCH(QVariant, disableHint);
     QFETCH(bool, mediaParametersDefined);
 
-    LipstickNotification *notification1 = new LipstickNotification;
-    LipstickNotification *notification2 = new LipstickNotification;
-    LipstickNotification *notification3 = new LipstickNotification;
     QVariantHash hints;
     hints.insert(NotificationManager::HINT_FEEDBACK, "feedback");
     if (disableHint.isValid()) {
         hints.insert(NotificationManager::HINT_LED_DISABLED_WITHOUT_BODY_AND_SUMMARY, disableHint);
     }
-    notification1->setHints(hints);
-    notification2->setHints(hints);
-    notification3->setHints(hints);
-    notification2->setSummary("summary");
-    notification3->setBody("body");
+    LipstickNotification *notification1 = new LipstickNotification("ut_notificationfeedbackplayer", 1, "", "", "", QStringList(), hints, -1);
+    LipstickNotification *notification2 = new LipstickNotification("ut_notificationfeedbackplayer", 2, "", "summary", "", QStringList(), hints, -1);
+    LipstickNotification *notification3 = new LipstickNotification("ut_notificationfeedbackplayer", 3, "", "", "body", QStringList(), hints, -1);
     notificationManagerNotification.insert(1, notification1);
     notificationManagerNotification.insert(2, notification2);
     notificationManagerNotification.insert(3, notification3);

--- a/tests/ut_notificationpreviewpresenter/ut_notificationpreviewpresenter.cpp
+++ b/tests/ut_notificationpreviewpresenter/ut_notificationpreviewpresenter.cpp
@@ -145,6 +145,12 @@ void NotificationManager::CloseNotification(uint id, NotificationClosedReason)
     notificationManagerCloseNotificationIds.append(id);
 }
 
+QList<uint> notificationManagerDisplayedNotificationIds;
+void NotificationManager::MarkNotificationDisplayed(uint id)
+{
+    notificationManagerDisplayedNotificationIds.append(id);
+}
+
 NotificationManager *notificationManagerInstance = 0;
 NotificationManager *NotificationManager::instance()
 {
@@ -200,6 +206,7 @@ void Ut_NotificationPreviewPresenter::cleanup()
     qDeleteAll(notificationManagerNotification);
     notificationManagerNotification.clear();
     notificationManagerCloseNotificationIds.clear();
+    notificationManagerDisplayedNotificationIds.clear();
     gQmLocksStub->stubReset();
     gQmDisplayStateStub->stubReset();
 }
@@ -514,7 +521,7 @@ void Ut_NotificationPreviewPresenter::testNotificationNotShownIfTouchScreenIsLoc
     QCOMPARE(presentedSpy.count(), presentedCount);
 }
 
-void Ut_NotificationPreviewPresenter::testCriticalNotificationIsClosedAfterShowing()
+void Ut_NotificationPreviewPresenter::testCriticalNotificationIsMarkedAfterShowing()
 {
     NotificationPreviewPresenter presenter;
     createNotification(1, 2);
@@ -524,14 +531,23 @@ void Ut_NotificationPreviewPresenter::testCriticalNotificationIsClosedAfterShowi
     presenter.updateNotification(1);
     presenter.updateNotification(2);
     presenter.updateNotification(3);
+    QCOMPARE(notificationManagerDisplayedNotificationIds.count(), 0);
     QCOMPARE(notificationManagerCloseNotificationIds.count(), 0);
 
     presenter.showNextNotification();
-    QCOMPARE(notificationManagerCloseNotificationIds.count(), 1);
-    QCOMPARE(notificationManagerCloseNotificationIds.at(0), (uint)1);
+    QCOMPARE(notificationManagerDisplayedNotificationIds.count(), 1);
+    QCOMPARE(notificationManagerDisplayedNotificationIds.at(0), (uint)1);
+    QCOMPARE(notificationManagerCloseNotificationIds.count(), 0);
 
     presenter.showNextNotification();
-    QCOMPARE(notificationManagerCloseNotificationIds.count(), 1);
+    QCOMPARE(notificationManagerDisplayedNotificationIds.count(), 2);
+    QCOMPARE(notificationManagerDisplayedNotificationIds.at(1), (uint)2);
+    QCOMPARE(notificationManagerCloseNotificationIds.count(), 0);
+
+    presenter.showNextNotification();
+    QCOMPARE(notificationManagerDisplayedNotificationIds.count(), 3);
+    QCOMPARE(notificationManagerDisplayedNotificationIds.at(2), (uint)3);
+    QCOMPARE(notificationManagerCloseNotificationIds.count(), 0);
 }
 
 QWaylandSurface *surface = (QWaylandSurface *)1;

--- a/tests/ut_notificationpreviewpresenter/ut_notificationpreviewpresenter.h
+++ b/tests/ut_notificationpreviewpresenter/ut_notificationpreviewpresenter.h
@@ -37,7 +37,7 @@ private slots:
     void testUpdateNotificationRemovesNotificationFromQueueIfNotShowable();
     void testNotificationNotShownIfTouchScreenIsLockedAndDisplayIsOff_data();
     void testNotificationNotShownIfTouchScreenIsLockedAndDisplayIsOff();
-    void testCriticalNotificationIsClosedAfterShowing();
+    void testCriticalNotificationIsMarkedAfterShowing();
     void testNotificationPreviewsDisabled_data();
     void testNotificationPreviewsDisabled();
 };


### PR DESCRIPTION
Rather than automatically closing notifications with Critical urgency, mark them as displayed so that their expiry timeout can take effect.