### PR TITLE
[lipstick] Adjust urgency and expiry values for system notification categories

### DIFF
--- a/src/notificationcategories/device.added.conf
+++ b/src/notificationcategories/device.added.conf
@@ -1,3 +1,4 @@
 x-nemo-icon=icon-system-usb
-urgency=2
+urgency=1
+transient=true
 x-nemo-feedback=accessory_connected

--- a/src/notificationcategories/device.conf
+++ b/src/notificationcategories/device.conf
@@ -1,2 +1,3 @@
 x-nemo-icon=icon-system-bluetooth-device
-urgency=2
+urgency=0
+transient=true

--- a/src/notificationcategories/device.error.conf
+++ b/src/notificationcategories/device.error.conf
@@ -1,3 +1,4 @@
 x-nemo-icon=icon-system-usb
 urgency=2
+transient=true
 x-nemo-feedback=general_warning

--- a/src/notificationcategories/device.removed.conf
+++ b/src/notificationcategories/device.removed.conf
@@ -1,2 +1,3 @@
 x-nemo-icon=icon-system-usb
-urgency=2
+urgency=1
+transient=true

--- a/src/notificationcategories/network.conf
+++ b/src/notificationcategories/network.conf
@@ -1,2 +1,3 @@
 x-nemo-icon=icon-system-resources
-urgency=2
+urgency=0
+transient=true

--- a/src/notificationcategories/network.connected.conf
+++ b/src/notificationcategories/network.connected.conf
@@ -1,2 +1,3 @@
 x-nemo-icon=icon-system-resources
-urgency=2
+urgency=1
+transient=true

--- a/src/notificationcategories/network.disconnected.conf
+++ b/src/notificationcategories/network.disconnected.conf
@@ -1,2 +1,3 @@
 x-nemo-icon=icon-system-resources
-urgency=2
+urgency=1
+transient=true

--- a/src/notificationcategories/network.error.conf
+++ b/src/notificationcategories/network.error.conf
@@ -1,2 +1,3 @@
 x-nemo-icon=icon-system-resources
 urgency=2
+transient=true

--- a/src/notificationcategories/x-nemo.battery.chargingcomplete.conf
+++ b/src/notificationcategories/x-nemo.battery.chargingcomplete.conf
@@ -1,2 +1,3 @@
 x-nemo-icon=icon-system-charging
-urgency=2
+urgency=1
+transient=true

--- a/src/notificationcategories/x-nemo.battery.chargingnotstarted.conf
+++ b/src/notificationcategories/x-nemo.battery.chargingnotstarted.conf
@@ -1,3 +1,4 @@
 x-nemo-icon=icon-system-battery
 urgency=2
+expireTimeout=60000
 x-nemo-feedback=general_warning

--- a/src/notificationcategories/x-nemo.battery.conf
+++ b/src/notificationcategories/x-nemo.battery.conf
@@ -1,3 +1,4 @@
 x-nemo-icon=icon-system-charging
-urgency=2
+urgency=0
+transient=true
 x-nemo-feedback=charging_started

--- a/src/notificationcategories/x-nemo.battery.enterpsm.conf
+++ b/src/notificationcategories/x-nemo.battery.enterpsm.conf
@@ -1,3 +1,4 @@
 x-nemo-icon=icon-system-battery
-urgency=2
+urgency=0
+transient=true
 x-nemo-feedback=battery_low

--- a/src/notificationcategories/x-nemo.battery.exitpsm.conf
+++ b/src/notificationcategories/x-nemo.battery.exitpsm.conf
@@ -1,2 +1,3 @@
 x-nemo-icon=icon-system-battery
-urgency=2
+urgency=0
+transient=true

--- a/src/notificationcategories/x-nemo.battery.lowbattery.conf
+++ b/src/notificationcategories/x-nemo.battery.lowbattery.conf
@@ -1,3 +1,4 @@
 x-nemo-icon=icon-system-battery
-urgency=2
+urgency=1
+expireTimeout=60000
 x-nemo-feedback=battery_low

--- a/src/notificationcategories/x-nemo.battery.notenoughpower.conf
+++ b/src/notificationcategories/x-nemo.battery.notenoughpower.conf
@@ -1,2 +1,3 @@
 x-nemo-icon=icon-system-battery
-urgency=2
+urgency=1
+expireTimout=60000

--- a/src/notificationcategories/x-nemo.battery.recharge.conf
+++ b/src/notificationcategories/x-nemo.battery.recharge.conf
@@ -1,3 +1,4 @@
 x-nemo-icon=icon-system-battery
 urgency=2
+transient=true
 x-nemo-feedback=battery_empty

--- a/src/notificationcategories/x-nemo.battery.removecharger.conf
+++ b/src/notificationcategories/x-nemo.battery.removecharger.conf
@@ -1,2 +1,3 @@
 x-nemo-icon=icon-system-charging
-urgency=2
+urgency=1
+expireTimeout=60000

--- a/src/notificationcategories/x-nemo.battery.shutdown.conf
+++ b/src/notificationcategories/x-nemo.battery.shutdown.conf
@@ -1,3 +1,4 @@
 x-nemo-icon=icon-system-battery
 urgency=2
+transient=true
 x-nemo-feedback=battery_empty

--- a/src/notificationcategories/x-nemo.battery.temperature.conf
+++ b/src/notificationcategories/x-nemo.battery.temperature.conf
@@ -1,3 +1,4 @@
 x-nemo-icon=icon-system-warning
-urgency=2
+urgency=1
+expireTimeout=60000
 x-nemo-feedback=general_warning

--- a/src/notificationcategories/x-nemo.connectionselector.cellular.conf
+++ b/src/notificationcategories/x-nemo.connectionselector.cellular.conf
@@ -1,2 +1,3 @@
 x-nemo-icon=icon-m-mobile-network
-urgency=2
+urgency=1
+transient=true

--- a/src/notificationcategories/x-nemo.connectionselector.wifi.conf
+++ b/src/notificationcategories/x-nemo.connectionselector.wifi.conf
@@ -1,2 +1,3 @@
 x-nemo-icon=icon-m-wlan
-urgency=2
+urgency=1
+transient=true

--- a/src/notificationcategories/x-nemo.device.locked.conf
+++ b/src/notificationcategories/x-nemo.device.locked.conf
@@ -1,2 +1,3 @@
 x-nemo-icon=icon-system-warning
-urgency=2
+urgency=1
+transient=true

--- a/src/notificationcategories/x-nemo.diskspace.low.conf
+++ b/src/notificationcategories/x-nemo.diskspace.low.conf
@@ -1,1 +1,3 @@
 x-nemo-icon=icon-lock-warning
+urgency=2
+expireTimeout=60000

--- a/src/notificationcategories/x-nemo.system.diskspace.conf
+++ b/src/notificationcategories/x-nemo.system.diskspace.conf
@@ -1,2 +1,3 @@
 x-nemo-icon=icon-system-resources
-urgency=2
+urgency=1
+transient=true


### PR DESCRIPTION
'urgency=2' is no longer required for notifications to be automatically removed after display, instead use 'expireTimeout=0'.

Depends on: https://github.com/nemomobile/lipstick/pull/250