### PR TITLE
[lipstick] Always clear LauncherItem.isLaunching after a set timeout.

### DIFF
--- a/src/components/launcheritem.h
+++ b/src/components/launcheritem.h
@@ -21,6 +21,7 @@
 #include <QObject>
 #include <QStringList>
 #include <QSharedPointer>
+#include <QBasicTimer>
 
 // Define this if you'd like to see debug messages from the launcher
 #ifdef DEBUG_LAUNCHER
@@ -58,6 +59,7 @@ class LIPSTICK_EXPORT LauncherItem : public QObject
     Q_PROPERTY(int updatingProgress READ updatingProgress WRITE setUpdatingProgress NOTIFY updatingProgressChanged)
 
     QSharedPointer<MDesktopEntry> _desktopEntry;
+    QBasicTimer _launchingTimeout;
     bool _isLaunching;
     bool _isUpdating;
     bool _isTemporary;
@@ -121,6 +123,9 @@ signals:
     void isTemporaryChanged();
     void packageNameChanged();
     void updatingProgressChanged();
+
+protected:
+    void timerEvent(QTimerEvent *event);
 };
 
 #endif // LAUNCHERITEM_H

--- a/src/components/launchermodel.cpp
+++ b/src/components/launchermodel.cpp
@@ -463,10 +463,12 @@ void LauncherModel::updatingFinished(const QString &packageName,
 void LauncherModel::notifyLaunching(const QString &desktopFile)
 {
     LauncherItem *item = itemInModel(desktopFile);
-    if (item)
+    if (item) {
+        item->setIsLaunching(true);
         emit notifyLaunching(item);
-    else
+    } else {
         qWarning("No launcher item found for \"%s\".", qPrintable(desktopFile));
+    }
 }
 
 void LauncherModel::updateWatchedDBusServices()


### PR DESCRIPTION
If isLaunching was set true by launchApplication it would be reset
after 5 seconds to allow for failed starts.  Extend this protection
to all means of setting isLaunching.