### PR TITLE
[lipstick] Fix crash when a compositor window is removed from the scene.

### DIFF
--- a/src/compositor/lipstickcompositorwindow.cpp
+++ b/src/compositor/lipstickcompositorwindow.cpp
@@ -221,6 +221,14 @@ bool LipstickCompositorWindow::isInProcess() const
     return false;
 }
 
+void LipstickCompositorWindow::itemChange(ItemChange change, const ItemChangeData &data)
+{
+    if (change == ItemSceneChange) {
+        handleTouchCancel();
+    }
+    QWaylandSurfaceItem::itemChange(change, data);
+}
+
 bool LipstickCompositorWindow::event(QEvent *e)
 {
     bool rv = QWaylandSurfaceItem::event(e);
@@ -337,7 +345,8 @@ void LipstickCompositorWindow::handleTouchCancel()
         inputDevice->sendTouchCancelEvent();
         inputDevice->setMouseFocus(0, QPointF());
     }
-    window()->removeEventFilter(this);
+    if (QWindow *w = window())
+        w->removeEventFilter(this);
     m_interceptingTouch = false;
 }
 

--- a/src/compositor/lipstickcompositorwindow.h
+++ b/src/compositor/lipstickcompositorwindow.h
@@ -59,6 +59,8 @@ public:
     Q_INVOKABLE void terminateProcess(int killTimeout);
 
 protected:
+    void itemChange(ItemChange change, const ItemChangeData &data);
+
     virtual bool event(QEvent *);
     virtual void mousePressEvent(QMouseEvent *event);
     virtual void mouseMoveEvent(QMouseEvent *event);


### PR DESCRIPTION
Ensure touchs are canceled when the item's window changes, and verify
the window() pointer before dereferencing it.