### PR TITLE
[lipstick] Look up notification app properties by PID

### DIFF
--- a/src/notifications/notificationmanager.cpp
+++ b/src/notifications/notificationmanager.cpp
@@ -102,6 +102,8 @@ QPair<QString, QString> processProperties(uint pid)
                             it = nameProperties.insert(basename, qMakePair(desktopEntry.name(), desktopEntry.icon()));
                         } else {
                             qWarning() << "No desktop entry for process name:" << processName;
+                            // Fallback to the basename for application name
+                            it = nameProperties.insert(basename, qMakePair(basename, QString()));
                         }
                     }
                     if (it != nameProperties.end()) {

--- a/src/notifications/notificationmanager.h
+++ b/src/notifications/notificationmanager.h
@@ -21,6 +21,7 @@
 #include <QObject>
 #include <QTimer>
 #include <QSet>
+#include <QDBusContext>
 
 class CategoryDefinitionStore;
 class QSqlDatabase;
@@ -35,7 +36,7 @@ class QSqlDatabase;
  * The service is registered as org.freedesktop.Notifications on the D-Bus
  * session bus in the path /org/freedesktop/Notifications.
  */
-class LIPSTICK_EXPORT NotificationManager : public QObject
+class LIPSTICK_EXPORT NotificationManager : public QObject, public QDBusContext
 {
     Q_OBJECT
 


### PR DESCRIPTION
If a notification does not specify the name or icon associated with the originating application, attempt to determine the values by inspecting the desktop file associated with the PID from which the notification was dispatched.