### PR TITLE
[lipstick] Separate ownership from appName property

### DIFF
--- a/src/notifications/lipsticknotification.cpp
+++ b/src/notifications/lipsticknotification.cpp
@@ -296,6 +296,11 @@ QString LipstickNotification::origin() const
     return hints_.value(NotificationManager::HINT_ORIGIN).toString();
 }
 
+QString LipstickNotification::owner() const
+{
+    return hints_.value(NotificationManager::HINT_OWNER).toString();
+}
+
 QDBusArgument &operator<<(QDBusArgument &argument, const LipstickNotification &notification)
 {
     argument.beginStructure();

--- a/src/notifications/lipsticknotification.h
+++ b/src/notifications/lipsticknotification.h
@@ -48,6 +48,7 @@ class LIPSTICK_EXPORT LipstickNotification : public QObject
     Q_PROPERTY(bool userRemovable READ isUserRemovable NOTIFY userRemovableChanged)
     Q_PROPERTY(QVariantList remoteActions READ remoteActions CONSTANT)
     Q_PROPERTY(QString origin READ origin CONSTANT)
+    Q_PROPERTY(QString owner READ owner CONSTANT)
 
 public:
     /*!
@@ -155,6 +156,9 @@ public:
 
     //! Returns an indicator for the origin of the notification
     QString origin() const;
+
+    //! Returns an indicator for the notification owner
+    QString owner() const;
 
     //! \internal
     /*!

--- a/src/notifications/notificationmanager.cpp
+++ b/src/notifications/notificationmanager.cpp
@@ -75,6 +75,7 @@ const char *NotificationManager::HINT_HIDDEN = "x-nemo-hidden";
 const char *NotificationManager::HINT_DISPLAY_ON = "x-nemo-display-on";
 const char *NotificationManager::HINT_LED_DISABLED_WITHOUT_BODY_AND_SUMMARY = "x-nemo-led-disabled-without-body-and-summary";
 const char *NotificationManager::HINT_ORIGIN = "x-nemo-origin";
+const char *NotificationManager::HINT_OWNER = "x-nemo-owner";
 
 namespace {
 
@@ -356,13 +357,13 @@ QString NotificationManager::GetServerInformation(QString &name, QString &vendor
     return QString();
 }
 
-NotificationList NotificationManager::GetNotifications(const QString &appName)
+NotificationList NotificationManager::GetNotifications(const QString &owner)
 {
     QList<LipstickNotification *> notificationList;
     QHash<uint, LipstickNotification *>::const_iterator it = notifications.constBegin(), end = notifications.constEnd();
     for ( ; it != end; ++it) {
         LipstickNotification *notification = it.value();
-        if (notification->appName() == appName) {
+        if (notification->owner() == owner) {
             notificationList.append(notification);
         }
     }

--- a/src/notifications/notificationmanager.h
+++ b/src/notifications/notificationmanager.h
@@ -116,6 +116,9 @@ public:
     //! Nemo hint: Indicates the origin of the notification
     static const char *HINT_ORIGIN;
 
+    //! Nemo hint: Indicates the identifer of the owner for notification
+    static const char *HINT_OWNER;
+
     //! Notifation closing reasons used in the NotificationClosed signal
     enum NotificationClosedReason {
         //! The notification expired.
@@ -203,10 +206,10 @@ public:
     /*!
      * Returns the notifications sent by a specified application.
      *
-     * \param appName the name of the application to get notifications for
+     * \param owner the identifier of the application to get notifications for
      * \return a list of notifications for the application
      */
-    NotificationList GetNotifications(const QString &appName);
+    NotificationList GetNotifications(const QString &owner);
 
 signals:
     /*!

--- a/tests/stubs/notificationmanager_stub.h
+++ b/tests/stubs/notificationmanager_stub.h
@@ -179,6 +179,7 @@ const char *NotificationManager::HINT_HIDDEN = "x-nemo-hidden";
 const char *NotificationManager::HINT_USER_REMOVABLE = "x-nemo-user-removable";
 const char *NotificationManager::HINT_LED_DISABLED_WITHOUT_BODY_AND_SUMMARY = "x-nemo-led-disabled-without-body-and-summary";
 const char *NotificationManager::HINT_ORIGIN = "x-nemo-origin";
+const char *NotificationManager::HINT_OWNER = "x-nemo-owner";
 
 NotificationManager *NotificationManager::instance_ = 0;
 NotificationManager * NotificationManager::instance() {

--- a/tests/ut_notificationfeedbackplayer/ut_notificationfeedbackplayer.cpp
+++ b/tests/ut_notificationfeedbackplayer/ut_notificationfeedbackplayer.cpp
@@ -37,6 +37,7 @@ const char *NotificationManager::HINT_USER_REMOVABLE = "x-nemo-user-removable";
 const char *NotificationManager::HINT_DISPLAY_ON = "x-nemo-display-on";
 const char *NotificationManager::HINT_LED_DISABLED_WITHOUT_BODY_AND_SUMMARY = "x-nemo-led-disabled-without-body-and-summary";
 const char *NotificationManager::HINT_ORIGIN = "x-nemo-origin";
+const char *NotificationManager::HINT_OWNER = "x-nemo-owner";
 
 NotificationManager::NotificationManager(QObject *parent) : QObject(parent)
 {

--- a/tests/ut_notificationpreviewpresenter/ut_notificationpreviewpresenter.cpp
+++ b/tests/ut_notificationpreviewpresenter/ut_notificationpreviewpresenter.cpp
@@ -110,6 +110,7 @@ const char *NotificationManager::HINT_REMOTE_ACTION_ICON_PREFIX = "x-nemo-remote
 const char *NotificationManager::HINT_HIDDEN = "x-nemo-hidden";
 const char *NotificationManager::HINT_USER_REMOVABLE = "x-nemo-user-removable";
 const char *NotificationManager::HINT_ORIGIN = "x-nemo-origin";
+const char *NotificationManager::HINT_OWNER = "x-nemo-owner";
 
 NotificationManager::NotificationManager(QObject *parent) : QObject(parent)
 {


### PR DESCRIPTION
Record the ownership of notifications explcitily to facilitate the Notification::notifications() accessor provided by nemo-qml-plugin-notifications, without requiring the appName property to have a default value.

This allows us to add a default appName value to the notifications if one is not provided.