### PR TITLE
[lipstick] Create display related component after compositor created.

### DIFF
--- a/src/compositor/lipstickcompositor.h
+++ b/src/compositor/lipstickcompositor.h
@@ -49,6 +49,7 @@ class LIPSTICK_EXPORT LipstickCompositor : public QQuickWindow, public QWaylandQ
     Q_PROPERTY(QObject* clipboard READ clipboard CONSTANT)
     Q_PROPERTY(QVariant orientationLock READ orientationLock NOTIFY orientationLockChanged)
     Q_PROPERTY(bool displayDimmed READ displayDimmed NOTIFY displayDimmedChanged)
+    Q_PROPERTY(bool completed READ completed NOTIFY completedChanged)
 
 public:
     LipstickCompositor();
@@ -82,7 +83,7 @@ public:
 
     QVariant orientationLock() const { return m_orientationLock->value("dynamic"); }
 
-    bool displayDimmed() const { return m_previousDisplayState == MeeGo::QmDisplayState::Dimmed; }
+    bool displayDimmed() const { return m_currentDisplayState == MeeGo::QmDisplayState::Dimmed; }
 
     QObject *clipboard() const;
 
@@ -99,6 +100,8 @@ public:
     LipstickCompositorProcWindow *mapProcWindow(const QString &title, const QString &category, const QRect &, QQuickItem *rootItem);
 
     QWaylandSurface *surfaceForId(int) const;
+
+    bool completed();
 
     void setUpdatesEnabled(bool enabled);
     QWaylandSurfaceView *createView(QWaylandSurface *surf) Q_DECL_OVERRIDE;
@@ -129,6 +132,8 @@ signals:
     void displayAboutToBeOn();
     void displayAboutToBeOff();
 
+    void completedChanged();
+
 private slots:
     void surfaceMapped();
     void surfaceUnmapped();
@@ -151,6 +156,8 @@ private slots:
     void clipboardDataChanged();
     void onVisibleChanged(bool visible);
     void onSurfaceDying();
+
+    void initialize();
 
 private:
     friend class LipstickCompositorWindow;
@@ -193,8 +200,9 @@ private:
     QOrientationSensor* m_orientationSensor;
     QPointer<QMimeData> m_retainedSelection;
     MGConfItem *m_orientationLock;
-    MeeGo::QmDisplayState::DisplayState m_previousDisplayState;
+    MeeGo::QmDisplayState::DisplayState m_currentDisplayState;
     bool m_updatesEnabled;
+    bool m_completed;
     int m_onUpdatesDisabledUnfocusedWindowId;
     LipstickRecorderManager *m_recorder;
 };

--- a/src/homeapplication.cpp
+++ b/src/homeapplication.cpp
@@ -250,9 +250,6 @@ void HomeApplication::setCompositorPath(const QString &path)
             // install default incubation controller
             qmlEngine->setIncubationController(LipstickCompositor::instance()->incubationController());
         }
-
-        if (LipstickCompositor::instance())
-            LipstickCompositor::instance()->show();
     } else {
         qWarning() << "HomeApplication: Error creating compositor from" << path;
         qWarning() << component.errors();

--- a/tests/stubs/lipstickcompositor_stub.h
+++ b/tests/stubs/lipstickcompositor_stub.h
@@ -54,6 +54,8 @@ class LipstickCompositorStub : public StubBase {
   virtual QWaylandSurfaceView *createView(QWaylandSurface *surf);
   virtual void onSurfaceDying();
   virtual void readContent();
+  virtual void initialize();
+  virtual bool completed();
 }; 
 
 // 2. IMPLEMENT STUB
@@ -219,6 +221,15 @@ void LipstickCompositorStub::onSurfaceDying() {
 
 void LipstickCompositorStub::readContent() {
     stubMethodEntered("readContent");
+}
+
+void LipstickCompositorStub::initialize() {
+    stubMethodEntered("initialize");
+}
+
+bool LipstickCompositorStub::completed() {
+    stubMethodEntered("completed");
+    return true;
 }
 
 #if QT_VERSION >= QT_VERSION_CHECK(5, 2, 0)
@@ -455,6 +466,14 @@ void LipstickCompositor::onSurfaceDying() {
 
 void LipstickCompositor::readContent() {
     gLipstickCompositorStub->readContent();
+}
+
+void LipstickCompositor::initialize() {
+    gLipstickCompositorStub->initialize();
+}
+
+bool LipstickCompositor::completed() {
+    return gLipstickCompositorStub->completed();
 }
 
 #if QT_VERSION < QT_VERSION_CHECK(5, 2, 0)


### PR DESCRIPTION
Rendering is supressed (updates enabled false) until MCE allows updates.

When single shot timer is triggered we register compositor
to dbus, create QmDisplayState instance, set initial state, and
connect signals.

MCE sends setUpdatesEnabled to compositor when we can start rendering
(when "org.nemomobile.compositor" gets registered).