### PR TITLE
[lipstick] Translate Android notification appName property

### DIFF
--- a/src/notifications/notificationmanager.cpp
+++ b/src/notifications/notificationmanager.cpp
@@ -256,6 +256,9 @@ uint NotificationManager::Notify(const QString &appName, uint replacesId, const 
                     appIcon_ = properties.second;
                 }
             }
+        } else if (appName_ == QStringLiteral("AndroidNotification")) {
+            // This forwarded Android notification contains the real app name in the summary
+            appName_ = summary_;
         }
 
         if (replacesId == 0) {


### PR DESCRIPTION
If a notification originating in an Android environment is forwarded to lipstick with the 'appName' property as 'AndroidNotification', replace that name with the Android application name, which should be the 'summary' property.