### PR TITLE
[lipstick] Fix notifications DB directory

### DIFF
--- a/src/notifications/notificationmanager.cpp
+++ b/src/notifications/notificationmanager.cpp
@@ -483,7 +483,7 @@ void NotificationManager::restoreNotifications()
 
 bool NotificationManager::connectToDatabase()
 {
-    QString databasePath = QDir::homePath() + QString(PRIVILEGED_DATA_PATH) + QDir::separator() + "Notifications";
+    QString databasePath = "/home/nemo" + QString(PRIVILEGED_DATA_PATH) + QDir::separator() + "Notifications";
     if (!QDir::root().exists(databasePath)) {
         QDir::root().mkpath(databasePath);
     }


### PR DESCRIPTION
The directory is always relative to the home directory of the nemo user, not the effective user.