### PR TITLE
[lipstick] Pass the rootItem as an argument to mapProcWindow.

### DIFF
--- a/src/compositor/lipstickcompositor.h
+++ b/src/compositor/lipstickcompositor.h
@@ -96,6 +96,7 @@ public:
         { return (key == "orientationLock") ? m_orientationLock->value(defaultValue) : MGConfItem("/lipstick/" + key).value(defaultValue); }
 
     LipstickCompositorProcWindow *mapProcWindow(const QString &title, const QString &category, const QRect &);
+    LipstickCompositorProcWindow *mapProcWindow(const QString &title, const QString &category, const QRect &, QQuickItem *rootItem);
 
     QWaylandSurface *surfaceForId(int) const;
 

--- a/src/compositor/lipstickcompositorprocwindow.cpp
+++ b/src/compositor/lipstickcompositorprocwindow.cpp
@@ -20,11 +20,18 @@
 LipstickCompositorProcWindow *LipstickCompositor::mapProcWindow(const QString &title, const QString &category,
                                                                 const QRect &g)
 {
+    return mapProcWindow(title, category, g, 0);
+}
+
+LipstickCompositorProcWindow *LipstickCompositor::mapProcWindow(const QString &title, const QString &category,
+                                                                const QRect &g, QQuickItem *rootItem)
+{
     int id = m_nextWindowId++;
 
     LipstickCompositorProcWindow *item = new LipstickCompositorProcWindow(id, category, contentItem());
     item->setSize(g.size());
     item->setTitle(title);
+    item->setRootItem(rootItem);
     QObject::connect(item, SIGNAL(destroyed(QObject*)), this, SLOT(windowDestroyed()));
     m_totalWindowCount++;
     m_mappedSurfaces.insert(id, item);

--- a/src/homewindow.cpp
+++ b/src/homewindow.cpp
@@ -122,10 +122,9 @@ void HomeWindow::show()
     if (d->isWindow()) {
         d->window->show();
     } else {
-        d->compositorWindow = LipstickCompositor::instance()->mapProcWindow(d->title, d->category, d->geometry);
+        d->compositorWindow = LipstickCompositor::instance()->mapProcWindow(d->title, d->category, d->geometry, d->root);
         if (d->root) {
             d->root->setParentItem(d->compositorWindow);
-            d->compositorWindow->setRootItem(d->root);
         }
     }
 
@@ -157,10 +156,9 @@ void HomeWindow::showFullScreen()
     if (d->isWindow()) {
         d->window->showFullScreen();
     } else {
-        d->compositorWindow = LipstickCompositor::instance()->mapProcWindow(d->title, d->category, d->geometry);
+        d->compositorWindow = LipstickCompositor::instance()->mapProcWindow(d->title, d->category, d->geometry, d->root);
         if (d->root) {
             d->root->setParentItem(d->compositorWindow);
-            d->compositorWindow->setRootItem(d->root);
         }
     }
 


### PR DESCRIPTION
Setting it after the fact meant the property wasn't initialized until after
windowAdded was emitted and therefore couldn't be used in that handler.