### PR TITLE
Unify diskspace notifications

### DIFF
--- a/src/notificationcategories/x-nemo.diskspace.low.conf
+++ b/src/notificationcategories/x-nemo.diskspace.low.conf
@@ -1,3 +1,0 @@
-x-nemo-icon=icon-lock-warning
-urgency=2
-expireTimeout=60000

--- a/src/notificationcategories/x-nemo.system.diskspace.conf
+++ b/src/notificationcategories/x-nemo.system.diskspace.conf
@@ -1,3 +1,5 @@
-x-nemo-icon=icon-system-resources
-urgency=1
-transient=true
+appIcon=icon-lock-warning
+urgency=2
+x-nemo-icon=icon-lock-warning
+x-nemo-preview-icon=icon-system-resources
+x-nemo-priority=70

--- a/src/notifications/diskspacenotifier.cpp
+++ b/src/notifications/diskspacenotifier.cpp
@@ -52,39 +52,17 @@ void DiskSpaceNotifier::handleDiskSpaceChange(const QString &path, int percentag
     }
 
     if (notificationShouldBeVisible) {
-        if (notificationId != 0) {
-            // Destroy any previous notification
-            NotificationManager *manager = NotificationManager::instance();
-            manager->CloseNotification(notificationId);
-        }
+        //% "Getting low with storage. Please check."
+        const QString diskLowText = qtTrId("qtn_memu_memlow_notification_src");
 
         // Show a system notification
-        NotificationManager *manager = NotificationManager::instance();
         QVariantHash hints;
         hints.insert(NotificationManager::HINT_CATEGORY, "x-nemo.system.diskspace");
-        //% "Getting low with storage. Please check."
-        QString diskLowText = qtTrId("qtn_memu_memlow_notification_src");
         hints.insert(NotificationManager::HINT_PREVIEW_BODY, diskLowText);
-        // TODO go to some relevant place when clicking the notification
-        notificationId = manager->Notify(qApp->applicationName(), 0, QString(), QString(), QString(), QStringList(), hints, -1);
 
-        bool nonSystemNotificationFound = false;
-        NotificationList notifications = manager->GetNotifications(qApp->applicationName());
-        foreach (LipstickNotification* notification, notifications.notifications()) {
-            if (notification->category() == "x-nemo.diskspace.low") {
-                nonSystemNotificationFound = true;
-                break;
-            }
-        }
-        if (!nonSystemNotificationFound) {
-            // Show a non-system notification
-            // TODO: Figure out if this could be combined with the system notification. Currently
-            //       the system notifications are deleted by NotificationPreviewPresenter class
-            //       after they've been displayed.
-            hints.clear();
-            hints.insert(NotificationManager::HINT_CATEGORY, "x-nemo.diskspace.low");
-            manager->Notify(qApp->applicationName(), 0, QString(), diskLowText, QString(), QStringList(), hints, -1);
-        }
+        // TODO go to some relevant place when clicking the notification
+        NotificationManager *manager = NotificationManager::instance();
+        notificationId = manager->Notify(qApp->applicationName(), notificationId, QString(), QString(), diskLowText, QStringList(), hints, -1);
     }
 }
 
@@ -93,7 +71,7 @@ void DiskSpaceNotifier::removeDiskSpaceNotifications()
     NotificationManager *manager = NotificationManager::instance();
     foreach (uint id, manager->notificationIds()) {
         LipstickNotification *notification = NotificationManager::instance()->notification(id);
-        if (notification->appName() == qApp->applicationName() && notification->category() == "x-nemo.system.diskspace") {
+        if (notification->category() == "x-nemo.system.diskspace") {
             manager->CloseNotification(id);
         }
     }

--- a/src/notifications/notificationlistmodel.cpp
+++ b/src/notifications/notificationlistmodel.cpp
@@ -125,7 +125,5 @@ void NotificationListModel::removeNotifications(const QList<uint> &ids)
 
 bool NotificationListModel::notificationShouldBeShown(LipstickNotification *notification)
 {
-    return !notification->hidden() &&
-           !(notification->body().isEmpty() && notification->summary().isEmpty()) &&
-           notification->urgency() < 2;
+    return !notification->hidden() && (!notification->body().isEmpty() || !notification->summary().isEmpty());
 }

--- a/tests/ut_diskspacenotifier/ut_diskspacenotifier.cpp
+++ b/tests/ut_diskspacenotifier/ut_diskspacenotifier.cpp
@@ -97,11 +97,11 @@ void Ut_DiskSpaceNotifier::testNotifications_data()
 
     // The stub implementation of NotificationManager::GetNotifications returns an empty
     // list, and thus the non-system disk space notifications are sometimes published twice.
-    QTest::newRow("Disk space of / reached threshold but not 100%") << "/" << 90 << "/" << 99 << 2 << 0;
-    QTest::newRow("Disk space of / reached threshold and then 100%") << "/" << 90 << "/" << 100 << 4 << 1;
-    QTest::newRow("Disk space of / reached 100% twice") << "/" << 100 << "/" << 100 << 2 << 0;
-    QTest::newRow("Disk space of / and /home reached threshold") << "/" << 90 << "/home" << 90 << 4 << 1;
-    QTest::newRow("Disk space of /home and /home/user/MyDocs reached 100%") << "/home" << 100 << "/home/user/MyDocs" << 100 << 4 << 1;
+    QTest::newRow("Disk space of / reached threshold but not 100%") << "/" << 90 << "/" << 99 << 1 << 0;
+    QTest::newRow("Disk space of / reached threshold and then 100%") << "/" << 90 << "/" << 100 << 2 << 0;
+    QTest::newRow("Disk space of / reached 100% twice") << "/" << 100 << "/" << 100 << 1 << 0;
+    QTest::newRow("Disk space of / and /home reached threshold") << "/" << 90 << "/home" << 90 << 2 << 0;
+    QTest::newRow("Disk space of /home and /home/user/MyDocs reached 100%") << "/home" << 100 << "/home/user/MyDocs" << 100 << 2 << 0;
 }
 
 void Ut_DiskSpaceNotifier::testNotifications()

--- a/tests/ut_notificationlistmodel/ut_notificationlistmodel.cpp
+++ b/tests/ut_notificationlistmodel/ut_notificationlistmodel.cpp
@@ -90,17 +90,6 @@ void Ut_NotificationListModel::testNotificationIsNotAddedIfNoSummaryOrBody()
     QCOMPARE(model.itemCount(), addItemCount);
 }
 
-void Ut_NotificationListModel::testNotificationIsNotAddedIfUrgencyIsCritical()
-{
-    QVariantHash hints;
-    hints.insert(NotificationManager::HINT_URGENCY, 2);
-    LipstickNotification notification("appName", 1, "appIcon", "summary", "body", QStringList() << "action", hints, 1);
-    gNotificationManagerStub->stubSetReturnValue("notificationIds", QList<uint>() << 1);
-    gNotificationManagerStub->stubSetReturnValue("notification", &notification);
-    NotificationListModel model;
-    QCOMPARE(model.itemCount(), 0);
-}
-
 void Ut_NotificationListModel::testNotificationIsNotAddedIfHidden()
 {
     QVariantHash hints;

--- a/tests/ut_notificationlistmodel/ut_notificationlistmodel.h
+++ b/tests/ut_notificationlistmodel/ut_notificationlistmodel.h
@@ -29,7 +29,6 @@ private slots:
     void testNotificationIsOnlyAddedIfNotAlreadyAdded();
     void testNotificationIsNotAddedIfNoSummaryOrBody_data();
     void testNotificationIsNotAddedIfNoSummaryOrBody();
-    void testNotificationIsNotAddedIfUrgencyIsCritical();
     void testNotificationIsNotAddedIfHidden();
     void testAlreadyAddedNotificationIsRemovedIfNoLongerAddable();
     void testNotificationRemoval();


### PR DESCRIPTION
Use only a single notification for diskspace warnings, and ensure it is correctly visible from the events view.