### PR TITLE
[lipstick] Don't enable the qt_key wayland extension. Fixes MER#925

### DIFF
--- a/src/compositor/lipstickcompositor.cpp
+++ b/src/compositor/lipstickcompositor.cpp
@@ -40,7 +40,7 @@
 LipstickCompositor *LipstickCompositor::m_instance = 0;
 
 LipstickCompositor::LipstickCompositor()
-    : QWaylandQuickCompositor(this)
+    : QWaylandQuickCompositor(this, 0, (QWaylandCompositor::ExtensionFlags)QWaylandCompositor::DefaultExtensions & ~QWaylandCompositor::QtKeyExtension)
     , m_totalWindowCount(0)
     , m_nextWindowId(1)
     , m_homeActive(true)

--- a/src/compositor/lipstickcompositorwindow.cpp
+++ b/src/compositor/lipstickcompositorwindow.cpp
@@ -220,7 +220,10 @@ bool LipstickCompositorWindow::eventFilter(QObject *obj, QEvent *event)
         QWaylandSurface *m_surface = surface();
         if (m_surface && m_grabbedKeys.contains(ke->key())) {
             QWaylandInputDevice *inputDevice = m_surface->compositor()->defaultInputDevice();
-            inputDevice->sendFullKeyEvent(m_surface, ke);
+            QWaylandSurface *old = inputDevice->keyboardFocus();
+            inputDevice->setKeyboardFocus(m_surface);
+            inputDevice->sendFullKeyEvent(ke);
+            inputDevice->setKeyboardFocus(old);
 
             return true;
         }


### PR DESCRIPTION
qt_key has some flaws, it doesn't support changing the keymap and
breaks the wayland abstraction giving the clients the events that
come directly from the platform lipstick is running on.