### PR TITLE
[lipstick] Restore critical urgency level to some notifications. Contributes to MER#915

### DIFF
--- a/src/notificationcategories/device.added.conf
+++ b/src/notificationcategories/device.added.conf
@@ -1,4 +1,4 @@
 x-nemo-icon=icon-system-usb
-urgency=1
+urgency=2
 transient=true
 x-nemo-feedback=accessory_connected

--- a/src/notificationcategories/device.removed.conf
+++ b/src/notificationcategories/device.removed.conf
@@ -1,3 +1,3 @@
 x-nemo-icon=icon-system-usb
-urgency=1
+urgency=2
 transient=true

--- a/src/notificationcategories/x-nemo.battery.chargingcomplete.conf
+++ b/src/notificationcategories/x-nemo.battery.chargingcomplete.conf
@@ -1,3 +1,3 @@
 x-nemo-icon=icon-system-charging
-urgency=1
+urgency=2
 transient=true

--- a/src/notificationcategories/x-nemo.battery.conf
+++ b/src/notificationcategories/x-nemo.battery.conf
@@ -1,4 +1,4 @@
 x-nemo-icon=icon-system-charging
-urgency=0
+urgency=2
 transient=true
 x-nemo-feedback=charging_started

--- a/src/notificationcategories/x-nemo.battery.enterpsm.conf
+++ b/src/notificationcategories/x-nemo.battery.enterpsm.conf
@@ -1,4 +1,4 @@
 x-nemo-icon=icon-system-battery
-urgency=0
+urgency=2
 transient=true
 x-nemo-feedback=battery_low

--- a/src/notificationcategories/x-nemo.battery.exitpsm.conf
+++ b/src/notificationcategories/x-nemo.battery.exitpsm.conf
@@ -1,3 +1,3 @@
 x-nemo-icon=icon-system-battery
-urgency=0
+urgency=2
 transient=true

--- a/src/notificationcategories/x-nemo.battery.lowbattery.conf
+++ b/src/notificationcategories/x-nemo.battery.lowbattery.conf
@@ -1,4 +1,4 @@
 x-nemo-icon=icon-system-battery
-urgency=1
+urgency=2
 expireTimeout=60000
 x-nemo-feedback=battery_low

--- a/src/notificationcategories/x-nemo.battery.notenoughpower.conf
+++ b/src/notificationcategories/x-nemo.battery.notenoughpower.conf
@@ -1,3 +1,3 @@
 x-nemo-icon=icon-system-battery
-urgency=1
+urgency=2
 expireTimout=60000

--- a/src/notificationcategories/x-nemo.battery.removecharger.conf
+++ b/src/notificationcategories/x-nemo.battery.removecharger.conf
@@ -1,3 +1,3 @@
 x-nemo-icon=icon-system-charging
-urgency=1
+urgency=2
 expireTimeout=60000

--- a/src/notificationcategories/x-nemo.battery.temperature.conf
+++ b/src/notificationcategories/x-nemo.battery.temperature.conf
@@ -1,4 +1,4 @@
 x-nemo-icon=icon-system-warning
-urgency=1
+urgency=2
 expireTimeout=60000
 x-nemo-feedback=general_warning

--- a/src/notificationcategories/x-nemo.connectionselector.cellular.conf
+++ b/src/notificationcategories/x-nemo.connectionselector.cellular.conf
@@ -1,3 +1,3 @@
 x-nemo-icon=icon-m-mobile-network
-urgency=1
+urgency=2
 transient=true

--- a/src/notificationcategories/x-nemo.connectionselector.wifi.conf
+++ b/src/notificationcategories/x-nemo.connectionselector.wifi.conf
@@ -1,3 +1,3 @@
 x-nemo-icon=icon-m-wlan
-urgency=1
+urgency=2
 transient=true

--- a/src/notificationcategories/x-nemo.device.locked.conf
+++ b/src/notificationcategories/x-nemo.device.locked.conf
@@ -1,3 +1,3 @@
 x-nemo-icon=icon-system-warning
-urgency=1
+urgency=2
 transient=true


### PR DESCRIPTION
Criticial urgency is required in order that these notifications are displayed even when the screen is locked.