### PR TITLE
[lipstick] Protect QObject instances from garbage collection. Contributes to MER#917

### DIFF
--- a/src/utilities/qobjectlistmodel.cpp
+++ b/src/utilities/qobjectlistmodel.cpp
@@ -16,6 +16,7 @@
 
 #include "qobjectlistmodel.h"
 #include "synchronizelists.h"
+#include <QQmlEngine>
 #include <QDebug>
 
 QObjectListModel::QObjectListModel(QObject *parent, QList<QObject*> *list)
@@ -194,7 +195,9 @@ QObject* QObjectListModel::get(int index)
     if (index >= _list->count() || index < 0)
         return 0;
 
-    return _list->at(index);
+    QObject *obj(_list->at(index));
+    QQmlEngine::setObjectOwnership(obj, QQmlEngine::CppOwnership);
+    return obj;
 }
 
 QList<QObject*> *QObjectListModel::getList()

--- a/tests/ut_launchermodel/ut_launchermodel.pro
+++ b/tests/ut_launchermodel/ut_launchermodel.pro
@@ -7,7 +7,7 @@ INCLUDEPATH += $$3RDPARTYSRCDIR
 
 QMAKE_CXXFLAGS += `pkg-config --cflags-only-I mlite5`
 
-QT += dbus
+QT += dbus qml
 
 SOURCES += \
     ut_launchermodel.cpp \

--- a/tests/ut_notificationlistmodel/ut_notificationlistmodel.pro
+++ b/tests/ut_notificationlistmodel/ut_notificationlistmodel.pro
@@ -3,7 +3,7 @@ TARGET = ut_notificationlistmodel
 INCLUDEPATH += $$NOTIFICATIONSRCDIR
 INCLUDEPATH += $$UTILITYSRCDIR
 INCLUDEPATH += $$3RDPARTYSRCDIR
-QT += sql dbus
+QT += sql dbus qml
 
 # unit test and unit
 SOURCES += \

--- a/tests/ut_qobjectlistmodel/ut_qobjectlistmodel.pro
+++ b/tests/ut_qobjectlistmodel/ut_qobjectlistmodel.pro
@@ -2,6 +2,7 @@ include(../common.pri)
 TARGET = ut_qobjectlistmodel
 INCLUDEPATH += $$UTILITYSRCDIR
 INCLUDEPATH += $$3RDPARTYSRCDIR
+QT += qml
 
 # unit test and unit
 SOURCES += \


### PR DESCRIPTION
QObject instances returned from Q_INVOKABLE functions become subject to garbage collection, unless explicitly protected.