### PR TITLE
[lipstick] Allow settings hardware keyboard layout with a property. Fixes MER#960

### DIFF
--- a/src/compositor/lipstickcompositor.cpp
+++ b/src/compositor/lipstickcompositor.cpp
@@ -592,6 +592,20 @@ void LipstickCompositor::setScreenOrientation(Qt::ScreenOrientation screenOrient
     }
 }
 
+QString LipstickCompositor::keyboardLayout() const
+{
+    return m_keyboardLayout;
+}
+
+void LipstickCompositor::setKeyboardLayout(const QString &layout)
+{
+    if (layout != m_keyboardLayout) {
+        m_keyboardLayout = layout;
+        defaultInputDevice()->setKeymap(QWaylandKeymap(m_keyboardLayout));
+        emit keyboardLayoutChanged();
+    }
+}
+
 void LipstickCompositor::reactOnDisplayStateChanges(MeeGo::QmDisplayState::DisplayState state)
 {
     if (m_currentDisplayState == state) {

--- a/src/compositor/lipstickcompositor.h
+++ b/src/compositor/lipstickcompositor.h
@@ -50,6 +50,7 @@ class LIPSTICK_EXPORT LipstickCompositor : public QQuickWindow, public QWaylandQ
     Q_PROPERTY(QVariant orientationLock READ orientationLock NOTIFY orientationLockChanged)
     Q_PROPERTY(bool displayDimmed READ displayDimmed NOTIFY displayDimmedChanged)
     Q_PROPERTY(bool completed READ completed NOTIFY completedChanged)
+    Q_PROPERTY(QString keyboardLayout READ keyboardLayout WRITE setKeyboardLayout NOTIFY keyboardLayoutChanged)
 
 public:
     LipstickCompositor();
@@ -84,6 +85,9 @@ public:
     QVariant orientationLock() const { return m_orientationLock->value("dynamic"); }
 
     bool displayDimmed() const { return m_currentDisplayState == MeeGo::QmDisplayState::Dimmed; }
+
+    QString keyboardLayout() const;
+    void setKeyboardLayout(const QString &layout);
 
     QObject *clipboard() const;
 
@@ -126,6 +130,7 @@ signals:
     void sensorOrientationChanged();
     void orientationLockChanged();
     void displayDimmedChanged();
+    void keyboardLayoutChanged();
 
     void displayOn();
     void displayOff();
@@ -205,6 +210,7 @@ private:
     bool m_completed;
     int m_onUpdatesDisabledUnfocusedWindowId;
     LipstickRecorderManager *m_recorder;
+    QString m_keyboardLayout;
 };
 
 #endif // LIPSTICKCOMPOSITOR_H

--- a/tests/stubs/lipstickcompositor_stub.h
+++ b/tests/stubs/lipstickcompositor_stub.h
@@ -476,6 +476,13 @@ bool LipstickCompositor::completed() {
     return gLipstickCompositorStub->completed();
 }
 
+void LipstickCompositor::setKeyboardLayout(const QString &) {
+}
+
+QString LipstickCompositor::keyboardLayout() const {
+    return QString();
+}
+
 #if QT_VERSION < QT_VERSION_CHECK(5, 2, 0)
 QWaylandCompositor::QWaylandCompositor(QWindow *, const char *)
 #else


### PR DESCRIPTION
For starters, did a simple workaround for QtWayland bug. I think it should protect against invalid layouts while allowing relevant ones.

(cc: @giucam)