### PR TITLE
[lipstick] Fix disappearing transformed HWC nodes.  Fixes MER#974

### DIFF
--- a/src/compositor/hwcrenderstage.cpp
+++ b/src/compositor/hwcrenderstage.cpp
@@ -424,7 +424,7 @@ bool HwcRenderStage::checkSceneGraph(QSGNode *node)
         }
 
         if (!hwc_renderstage_isTranslate(cm))
-            return true;
+            return false;
 
         hwc_renderstage_check_node(hwcNode);
         hwcNode->setPos(cm(0, 3), cm(1, 3));


### PR DESCRIPTION
A node which has an accumulative transform that is anything other than
a translation it is not hwcomposer compatible, return false in this
case instead of true.