### PR TITLE
[lipstick] Don't dismiss the lockscreen when usb is connected. Fixes …

### DIFF
--- a/src/homeapplication.cpp
+++ b/src/homeapplication.cpp
@@ -99,7 +99,6 @@ HomeApplication::HomeApplication(int &argc, char **argv, const QString &qmlPath)
     new DiskSpaceNotifier(this);
     new ThermalNotifier(this);
     usbModeSelector = new USBModeSelector(this);
-    connect(usbModeSelector, SIGNAL(dialogShown()), screenLock, SLOT(unlockScreen()));
     shutdownScreen = new ShutdownScreen(this);
     new ShutdownScreenAdaptor(shutdownScreen);
     connectionSelector = new ConnectionSelector(this);


### PR DESCRIPTION
…MER#975

All that's really needed is for the display to be turned on and that
can be done as a generic part of showing dialogs.