### PR TITLE
[lipstick] Ensure correct sorting of notifications. Contributes to MER#991

### DIFF
--- a/src/notifications/notificationlistmodel.cpp
+++ b/src/notifications/notificationlistmodel.cpp
@@ -75,6 +75,10 @@ void NotificationListModel::updateNotification(uint id)
                 // If the new index is the existing index + 1, there is no actual movement
                 update(currentIndex);
             } else {
+                // QObjectListModel::move works like QList::move - the insertion is performed after the extraction
+                if (newIndex > currentIndex) {
+                    newIndex -= 1;
+                }
                 move(currentIndex, newIndex);
             }
         } else if (currentIndex >= 0) {

--- a/src/notifications/notificationlistmodel.cpp
+++ b/src/notifications/notificationlistmodel.cpp
@@ -65,18 +65,19 @@ void NotificationListModel::updateNotification(uint id)
     LipstickNotification *notification = NotificationManager::instance()->notification(id);
 
     if (notification != 0) {
-        int index = indexOf(notification);
+        int currentIndex = indexOf(notification);
         if (notificationShouldBeShown(notification)) {
             // Place the notifications in the model latest first, moving existing notifications if necessary
-            int expectedIndex = indexFor(notification);
-            if (index < 0) {
-                insertItem(expectedIndex, notification);
-            } else if (index != expectedIndex) {
-                move(index, expectedIndex);
+            int newIndex = indexFor(notification);
+            if (currentIndex < 0) {
+                insertItem(newIndex, notification);
+            } else if (newIndex == currentIndex || newIndex == (currentIndex + 1)) {
+                // If the new index is the existing index + 1, there is no actual movement
+                update(currentIndex);
             } else {
-                update(index);
+                move(currentIndex, newIndex);
             }
-        } else if (index >= 0) {
+        } else if (currentIndex >= 0) {
             removeItem(notification);
         }
     }
@@ -86,8 +87,16 @@ int NotificationListModel::indexFor(LipstickNotification *notification)
 {
     for (int index = 0; index < itemCount(); index++) {
         LipstickNotification *notificationAtIndex = static_cast<LipstickNotification *>(get(index));
-        if (notificationAtIndex->timestamp() <= notification->timestamp()) {
+        if (notification->replacesId() == notificationAtIndex->replacesId()) {
+            continue;
+        }
+
+        if (notification->timestamp() > notificationAtIndex->timestamp()) {
             return index;
+        } else if (notification->timestamp() == notificationAtIndex->timestamp()) {
+            if (notification->replacesId() > notificationAtIndex->replacesId()) {
+                return index;
+            }
         }
     }
     return itemCount();

--- a/tests/ut_notificationlistmodel/ut_notificationlistmodel.cpp
+++ b/tests/ut_notificationlistmodel/ut_notificationlistmodel.cpp
@@ -127,8 +127,8 @@ void Ut_NotificationListModel::testNotificationOrdering()
     QVariantHash hints2;
     QVariantHash hints3;
     hints1.insert(NotificationManager::HINT_TIMESTAMP, QDateTime(QDate(2013, 1, 1), QTime(12, 34, 56)));
-    hints2.insert(NotificationManager::HINT_TIMESTAMP, QDateTime(QDate(2013, 1, 2), QTime(12, 34, 56)));
-    hints3.insert(NotificationManager::HINT_TIMESTAMP, QDateTime(QDate(2013, 1, 3), QTime(12, 34, 56)));
+    hints2.insert(NotificationManager::HINT_TIMESTAMP, QDateTime(QDate(2013, 1, 3), QTime(12, 34, 56)));
+    hints3.insert(NotificationManager::HINT_TIMESTAMP, QDateTime(QDate(2013, 1, 5), QTime(12, 34, 56)));
     LipstickNotification notification1("appName1", 1, "appIcon1", "summary1", "body1", QStringList() << "action1", hints1, 1);
     LipstickNotification notification2("appName2", 2, "appIcon2", "summary2", "body2", QStringList() << "action2", hints2, 1);
     LipstickNotification notification3("appName3", 3, "appIcon3", "summary3", "body3", QStringList() << "action3", hints3, 1);
@@ -143,7 +143,7 @@ void Ut_NotificationListModel::testNotificationOrdering()
     QCOMPARE(model.get(1), &notification2);
     QCOMPARE(model.get(2), &notification1);
 
-    hints1.insert(NotificationManager::HINT_TIMESTAMP, QDateTime(QDate(2013, 1, 4), QTime(12, 34, 56)));
+    hints1.insert(NotificationManager::HINT_TIMESTAMP, QDateTime(QDate(2013, 1, 7), QTime(12, 34, 56)));
     notification1.setHints(hints1);
     gNotificationManagerStub->stubSetReturnValue("notification", &notification1);
     model.updateNotification(1);
@@ -151,8 +151,13 @@ void Ut_NotificationListModel::testNotificationOrdering()
     QCOMPARE(model.get(1), &notification3);
     QCOMPARE(model.get(2), &notification2);
 
+    hints1.insert(NotificationManager::HINT_TIMESTAMP, QDateTime(QDate(2013, 1, 4), QTime(12, 34, 56)));
+    notification1.setHints(hints1);
+    gNotificationManagerStub->stubSetReturnValue("notification", &notification1);
     model.updateNotification(1);
-    QCOMPARE(model.get(0), &notification1);
+    QCOMPARE(model.get(0), &notification3);
+    QCOMPARE(model.get(1), &notification1);
+    QCOMPARE(model.get(2), &notification2);
 }
 
 void Ut_NotificationListModel::testNotificationUpdate()


### PR DESCRIPTION
The sorting function must provide a strict weak ordering depending on the properties of the sorted notifications independent of their current position in the list.  Use replacesId as the discriminator
when timestamp is equivalent.

Also, do not compare a notification to itself in the list, as the properties may have been updated since it was sorted into that position.