### PR TITLE
Don't send synthesized mouse events to clients

### DIFF
--- a/src/compositor/lipstickcompositorwindow.cpp
+++ b/src/compositor/lipstickcompositorwindow.cpp
@@ -258,7 +258,7 @@ void LipstickCompositorWindow::mousePressEvent(QMouseEvent *event)
 {
     QWaylandSurface *m_surface = surface();
     if (m_surface && (!m_mouseRegionValid || m_mouseRegion.contains(event->pos())) &&
-        m_surface->inputRegionContains(event->pos())) {
+        m_surface->inputRegionContains(event->pos()) && event->source() != Qt::MouseEventSynthesizedByQt) {
         QWaylandInputDevice *inputDevice = m_surface->compositor()->defaultInputDevice();
         if (inputDevice->mouseFocus() != this) {
             inputDevice->setMouseFocus(this, event->pos(), event->globalPos());
@@ -275,7 +275,7 @@ void LipstickCompositorWindow::mousePressEvent(QMouseEvent *event)
 void LipstickCompositorWindow::mouseMoveEvent(QMouseEvent *event)
 {
     QWaylandSurface *m_surface = surface();
-    if (m_surface){
+    if (m_surface && event->source() != Qt::MouseEventSynthesizedByQt) {
         QWaylandInputDevice *inputDevice = m_surface->compositor()->defaultInputDevice();
         inputDevice->sendMouseMoveEvent(this, event->pos(), event->globalPos());
     } else {
@@ -286,7 +286,7 @@ void LipstickCompositorWindow::mouseMoveEvent(QMouseEvent *event)
 void LipstickCompositorWindow::mouseReleaseEvent(QMouseEvent *event)
 {
     QWaylandSurface *m_surface = surface();
-    if (m_surface){
+    if (m_surface && event->source() != Qt::MouseEventSynthesizedByQt) {
         QWaylandInputDevice *inputDevice = m_surface->compositor()->defaultInputDevice();
         inputDevice->sendMouseReleaseEvent(event->button(), event->pos(), event->globalPos());
     } else {


### PR DESCRIPTION
Depends on https://github.com/mer-qt/qtdeclarative/pull/70 and https://github.com/mer-qt/qtbase/pull/40. 
This fixes the same bug as #297 but in a imho better way. We simply avoid sending mouse events to clients if the events are synthesized, this way the qtwayland state is kept sane.