### PR TITLE
[lipstick] Do not return appIcon property. Contributes to MER#1012

### DIFF
--- a/src/notifications/lipsticknotification.cpp
+++ b/src/notifications/lipsticknotification.cpp
@@ -181,7 +181,8 @@ void LipstickNotification::setExpireTimeout(int expireTimeout)
 
 QString LipstickNotification::icon() const
 {
-    return appIcon_.isEmpty() ? hints_.value(NotificationManager::HINT_ICON).toString() : appIcon_;
+    const QString hintIcon(hints_.value(NotificationManager::HINT_ICON).toString());
+    return hintIcon.isEmpty() ? appIcon_ : hintIcon;
 }
 
 QDateTime LipstickNotification::timestamp() const


### PR DESCRIPTION
The appIcon property is used for notification grouping, which is not required for the 1.1.6 release series.