### PR TITLE
Delay hiding the compositor window

### DIFF
--- a/src/compositor/lipstickcompositor.h
+++ b/src/compositor/lipstickcompositor.h
@@ -24,6 +24,8 @@
 #include <QPointer>
 #include <MGConfItem>
 #include <qmdisplaystate.h>
+#include <QDBusMessage>
+#include <QDBusContext>
 
 class WindowModel;
 class LipstickCompositorWindow;
@@ -32,7 +34,7 @@ class QOrientationSensor;
 class LipstickRecorderManager;
 
 class LIPSTICK_EXPORT LipstickCompositor : public QQuickWindow, public QWaylandQuickCompositor,
-                                           public QQmlParserStatus
+                                           public QQmlParserStatus, public QDBusContext
 {
     Q_OBJECT
     Q_INTERFACES(QQmlParserStatus)
@@ -110,6 +112,9 @@ public:
     void setUpdatesEnabled(bool enabled);
     QWaylandSurfaceView *createView(QWaylandSurface *surf) Q_DECL_OVERRIDE;
 
+protected:
+    void timerEvent(QTimerEvent *e) Q_DECL_OVERRIDE;
+
 signals:
     void windowAdded(QObject *window);
     void windowRemoved(QObject *window);
@@ -181,6 +186,7 @@ private:
     void windowRemoved(int);
     void windowDestroyed(LipstickCompositorWindow *item);
     void readContent();
+    void stopRendering();
 
     QQmlComponent *shaderEffectComponent();
 
@@ -211,6 +217,7 @@ private:
     int m_onUpdatesDisabledUnfocusedWindowId;
     LipstickRecorderManager *m_recorder;
     QString m_keyboardLayout;
+    QDBusMessage m_displayOffReply;
 };
 
 #endif // LIPSTICKCOMPOSITOR_H

--- a/src/compositor/lipstickcompositor.h
+++ b/src/compositor/lipstickcompositor.h
@@ -22,6 +22,7 @@
 #include <QWaylandQuickCompositor>
 #include <QWaylandSurfaceItem>
 #include <QPointer>
+#include <QTimer>
 #include <MGConfItem>
 #include <qmdisplaystate.h>
 #include <QDBusMessage>
@@ -166,7 +167,6 @@ private slots:
     void clipboardDataChanged();
     void onVisibleChanged(bool visible);
     void onSurfaceDying();
-
     void initialize();
 
 private:
@@ -187,6 +187,7 @@ private:
     void windowDestroyed(LipstickCompositorWindow *item);
     void readContent();
     void stopRendering();
+    void surfaceCommitted();
 
     QQmlComponent *shaderEffectComponent();
 
@@ -218,6 +219,7 @@ private:
     LipstickRecorderManager *m_recorder;
     QString m_keyboardLayout;
     QDBusMessage m_displayOffReply;
+    bool m_fakeRepaintTriggered;
 };
 
 #endif // LIPSTICKCOMPOSITOR_H

--- a/tests/stubs/lipstickcompositor_stub.h
+++ b/tests/stubs/lipstickcompositor_stub.h
@@ -56,6 +56,7 @@ class LipstickCompositorStub : public StubBase {
   virtual void readContent();
   virtual void initialize();
   virtual bool completed();
+  virtual void timerEvent(QTimerEvent *e);
 }; 
 
 // 2. IMPLEMENT STUB
@@ -230,6 +231,13 @@ void LipstickCompositorStub::initialize() {
 bool LipstickCompositorStub::completed() {
     stubMethodEntered("completed");
     return true;
+}
+
+void LipstickCompositorStub::timerEvent(QTimerEvent *e)
+{
+    QList<ParameterBase*> params;
+    params.append( new Parameter<QTimerEvent *>(e));
+    stubMethodEntered("timerEvent", params);
 }
 
 #if QT_VERSION >= QT_VERSION_CHECK(5, 2, 0)
@@ -474,6 +482,11 @@ void LipstickCompositor::initialize() {
 
 bool LipstickCompositor::completed() {
     return gLipstickCompositorStub->completed();
+}
+
+void LipstickCompositor::timerEvent(QTimerEvent *e)
+{
+    gLipstickCompositorStub->timerEvent(e);
 }
 
 void LipstickCompositor::setKeyboardLayout(const QString &) {


### PR DESCRIPTION
We want to give the clients some time to stop drawing after the screen
goes blank, without blocking them.