### PR TITLE
[launchermodel] Only accept .desktop files in monitored paths (Fixes JB#29427)

### DIFF
--- a/src/components/launchermodel.cpp
+++ b/src/components/launchermodel.cpp
@@ -385,8 +385,13 @@ void LauncherModel::updatingStarted(const QString &packageName, const QString &l
             item->setIconFilename(iconPath);
         }
 
-        if (!desktopFile.isEmpty()) {
+        if (!desktopFile.isEmpty() && isDesktopFile(desktopFile)) {
+            // Only update the .desktop file name if we actually consider
+            // it a .desktop file in the paths we monitor for changes (JB#29427)
             item->setFilePath(desktopFile);
+            // XXX: Changing the .desktop file path might hide the icon;
+            // we don't handle this here, but expect onFilesUpdated() to be
+            // called with the correct file names via the filesystem monitor
         }
 
         if (QFile(desktopFile).exists()) {


### PR DESCRIPTION
**Primary problem:** For some packages that only install `/etc/xdg/autostart/<something>.desktop`, the store-client will notify the model about this file appearing. We then update the temporary icon for the in-progress installation with the new .desktop file name, and (as a consequence of the file actually existing) mark the icon as non-temporary.

**Primary fix:** Only accept .desktop file name changes if the .desktop file resides in one of the monitored directories where we expect application files ot be.

**Secondary problem:** If the .desktop file appears, but has its visibility set to `false`, lipstick won't update it if we change the .desktop filename without re-evaluating whether it should actually be shown. This is usually not a problem, because the visibility will be re-evaluated for monitored directories. However, if the .desktop file comes from a non-monitored directory, this update doesn't take place.

**Secondary fix:** Add a comment for future improvements. The primary fix should avoid that problem, but I'm not 100% sure it actually does. It shouldn't happen for the test cases that we have seen so far.