### PR TITLE
[lipstick] Support maxContentLines notification hint. Contributes to MER#1055

### DIFF
--- a/src/notifications/lipsticknotification.cpp
+++ b/src/notifications/lipsticknotification.cpp
@@ -311,6 +311,11 @@ QString LipstickNotification::owner() const
     return hints_.value(NotificationManager::HINT_OWNER).toString();
 }
 
+int LipstickNotification::maxContentLines() const
+{
+    return hints_.value(NotificationManager::HINT_MAX_CONTENT_LINES).toInt();
+}
+
 void LipstickNotification::updateHintValues()
 {
     hintValues_.clear();
@@ -332,6 +337,7 @@ void LipstickNotification::updateHintValues()
             hint.compare(NotificationManager::HINT_HIDDEN, Qt::CaseInsensitive) != 0 &&
             hint.compare(NotificationManager::HINT_ORIGIN, Qt::CaseInsensitive) != 0 &&
             hint.compare(NotificationManager::HINT_OWNER, Qt::CaseInsensitive) != 0 &&
+            hint.compare(NotificationManager::HINT_MAX_CONTENT_LINES, Qt::CaseInsensitive) != 0 &&
             !hint.startsWith(NotificationManager::HINT_REMOTE_ACTION_PREFIX, Qt::CaseInsensitive) &&
             !hint.startsWith(NotificationManager::HINT_REMOTE_ACTION_ICON_PREFIX, Qt::CaseInsensitive)) {
             hintValues_.insert(hint, it.value());

--- a/src/notifications/lipsticknotification.h
+++ b/src/notifications/lipsticknotification.h
@@ -50,6 +50,7 @@ class LIPSTICK_EXPORT LipstickNotification : public QObject
     Q_PROPERTY(QVariantList remoteActions READ remoteActions CONSTANT)
     Q_PROPERTY(QString origin READ origin CONSTANT)
     Q_PROPERTY(QString owner READ owner CONSTANT)
+    Q_PROPERTY(int maxContentLines READ maxContentLines CONSTANT)
 
 public:
     /*!
@@ -161,6 +162,9 @@ public:
 
     //! Returns an indicator for the notification owner
     QString owner() const;
+
+    //! Returns the maximum number of content lines requested for display
+    int maxContentLines() const;
 
     //! \internal
     /*!

--- a/src/notifications/notificationmanager.cpp
+++ b/src/notifications/notificationmanager.cpp
@@ -83,6 +83,7 @@ const char *NotificationManager::HINT_DISPLAY_ON = "x-nemo-display-on";
 const char *NotificationManager::HINT_LED_DISABLED_WITHOUT_BODY_AND_SUMMARY = "x-nemo-led-disabled-without-body-and-summary";
 const char *NotificationManager::HINT_ORIGIN = "x-nemo-origin";
 const char *NotificationManager::HINT_OWNER = "x-nemo-owner";
+const char *NotificationManager::HINT_MAX_CONTENT_LINES = "x-nemo-max-content-lines";
 
 namespace {
 
@@ -204,6 +205,7 @@ QStringList NotificationManager::GetCapabilities()
                          << "x-nemo-remote-actions"
                          << HINT_USER_REMOVABLE
                          << HINT_ORIGIN
+                         << HINT_MAX_CONTENT_LINES
                          << "x-nemo-get-notifications";
 }
 

--- a/src/notifications/notificationmanager.h
+++ b/src/notifications/notificationmanager.h
@@ -120,6 +120,9 @@ public:
     //! Nemo hint: Indicates the identifer of the owner for notification
     static const char *HINT_OWNER;
 
+    //! Nemo hint: Specifies the maximum number of content lines to display (including summary)
+    static const char *HINT_MAX_CONTENT_LINES;
+
     //! Notification closing reasons used in the NotificationClosed signal
     enum NotificationClosedReason {
         //! The notification expired.

--- a/tests/stubs/notificationmanager_stub.h
+++ b/tests/stubs/notificationmanager_stub.h
@@ -180,6 +180,7 @@ const char *NotificationManager::HINT_USER_REMOVABLE = "x-nemo-user-removable";
 const char *NotificationManager::HINT_LED_DISABLED_WITHOUT_BODY_AND_SUMMARY = "x-nemo-led-disabled-without-body-and-summary";
 const char *NotificationManager::HINT_ORIGIN = "x-nemo-origin";
 const char *NotificationManager::HINT_OWNER = "x-nemo-owner";
+const char *NotificationManager::HINT_MAX_CONTENT_LINES = "x-nemo-max-content-lines";
 
 NotificationManager *NotificationManager::instance_ = 0;
 NotificationManager * NotificationManager::instance() {

--- a/tests/ut_lipsticknotification/ut_lipsticknotification.cpp
+++ b/tests/ut_lipsticknotification/ut_lipsticknotification.cpp
@@ -32,6 +32,7 @@ void Ut_Notification::testGettersAndSetters()
     int urgency = 1;
     int itemCount = 1;
     int priority = 1;
+    int maxContentLines = 3;
     QString category = "category1";
     QStringList actions = QStringList() << "action1a" << "action1b";
     QDateTime timestamp = QDateTime::currentDateTime();
@@ -44,6 +45,7 @@ void Ut_Notification::testGettersAndSetters()
     hints.insert(NotificationManager::HINT_PREVIEW_BODY, previewBody);
     hints.insert(NotificationManager::HINT_URGENCY, urgency);
     hints.insert(NotificationManager::HINT_CATEGORY, category);
+    hints.insert(NotificationManager::HINT_MAX_CONTENT_LINES, maxContentLines);
     hints.insert("x-nemo.testing.custom-hint-value", M_PI);
     int expireTimeout = 1;
 
@@ -64,9 +66,11 @@ void Ut_Notification::testGettersAndSetters()
     QCOMPARE(notification.itemCount(), itemCount);
     QCOMPARE(notification.priority(), priority);
     QCOMPARE(notification.category(), category);
+    QCOMPARE(notification.maxContentLines(), maxContentLines);
     QVERIFY(notification.hintValues().count() > 0);
     QVERIFY(notification.hintValues().contains("x-nemo.testing.custom-hint-value"));
     QVERIFY(!notification.hintValues().contains(NotificationManager::HINT_CATEGORY));
+    QVERIFY(!notification.hintValues().contains(NotificationManager::HINT_MAX_CONTENT_LINES));
     QCOMPARE(notification.hintValues().value("x-nemo.testing.custom-hint-value").toDouble(), M_PI);
 
     appName = "appName2";

--- a/tests/ut_notificationfeedbackplayer/ut_notificationfeedbackplayer.cpp
+++ b/tests/ut_notificationfeedbackplayer/ut_notificationfeedbackplayer.cpp
@@ -38,6 +38,7 @@ const char *NotificationManager::HINT_DISPLAY_ON = "x-nemo-display-on";
 const char *NotificationManager::HINT_LED_DISABLED_WITHOUT_BODY_AND_SUMMARY = "x-nemo-led-disabled-without-body-and-summary";
 const char *NotificationManager::HINT_ORIGIN = "x-nemo-origin";
 const char *NotificationManager::HINT_OWNER = "x-nemo-owner";
+const char *NotificationManager::HINT_MAX_CONTENT_LINES = "x-nemo-max-content-lines";
 
 NotificationManager::NotificationManager(QObject *parent) : QObject(parent)
 {

--- a/tests/ut_notificationmanager/ut_notificationmanager.cpp
+++ b/tests/ut_notificationmanager/ut_notificationmanager.cpp
@@ -513,7 +513,7 @@ void Ut_NotificationManager::testCapabilities()
 {
     // Check the supported capabilities includes all the Nemo hints
     QStringList capabilities = NotificationManager::instance()->GetCapabilities();
-    QCOMPARE(capabilities.count(), 12);
+    QCOMPARE(capabilities.count(), 13);
     QCOMPARE((bool)capabilities.contains("body"), true);
     QCOMPARE((bool)capabilities.contains("actions"), true);
     QCOMPARE((bool)capabilities.contains(NotificationManager::HINT_ICON), true);
@@ -526,6 +526,7 @@ void Ut_NotificationManager::testCapabilities()
     QCOMPARE((bool)capabilities.contains(NotificationManager::HINT_USER_REMOVABLE), true);
     QCOMPARE((bool)capabilities.contains("x-nemo-get-notifications"), true);
     QCOMPARE((bool)capabilities.contains(NotificationManager::HINT_ORIGIN), true);
+    QCOMPARE((bool)capabilities.contains(NotificationManager::HINT_MAX_CONTENT_LINES), true);
 }
 
 void Ut_NotificationManager::testAddingNotification()

--- a/tests/ut_notificationpreviewpresenter/ut_notificationpreviewpresenter.cpp
+++ b/tests/ut_notificationpreviewpresenter/ut_notificationpreviewpresenter.cpp
@@ -112,6 +112,7 @@ const char *NotificationManager::HINT_USER_REMOVABLE = "x-nemo-user-removable";
 const char *NotificationManager::HINT_DISPLAY_ON = "x-nemo-display-on";
 const char *NotificationManager::HINT_ORIGIN = "x-nemo-origin";
 const char *NotificationManager::HINT_OWNER = "x-nemo-owner";
+const char *NotificationManager::HINT_MAX_CONTENT_LINES = "x-nemo-max-content-lines";
 
 NotificationManager::NotificationManager(QObject *parent) : QObject(parent)
 {


### PR DESCRIPTION
maxContentLines property can be used to indicate to the notification presenter how much content should be displayed for a specific notification.