### PR TITLE
[lipstick] Send the frame callbacks when the display is off. Fixes ME…

### DIFF
--- a/src/compositor/lipstickcompositor.h
+++ b/src/compositor/lipstickcompositor.h
@@ -22,6 +22,7 @@
 #include <QWaylandQuickCompositor>
 #include <QWaylandSurfaceItem>
 #include <QPointer>
+#include <QTimer>
 #include <MGConfItem>
 #include <qmdisplaystate.h>
 
@@ -112,6 +113,9 @@ public:
     void setUpdatesEnabled(bool enabled);
     QWaylandSurfaceView *createView(QWaylandSurface *surf) Q_DECL_OVERRIDE;
 
+protected:
+    void timerEvent(QTimerEvent *e) Q_DECL_OVERRIDE;
+
 signals:
     void windowAdded(QObject *window);
     void windowRemoved(QObject *window);
@@ -166,7 +170,6 @@ private slots:
     void onVisibleChanged(bool visible);
     void onSurfaceDying();
     void updateKeymap();
-
     void initialize();
 
 private:
@@ -186,6 +189,7 @@ private:
     void windowRemoved(int);
     void windowDestroyed(LipstickCompositorWindow *item);
     void readContent();
+    void surfaceCommitted();
 
     QQmlComponent *shaderEffectComponent();
 
@@ -217,6 +221,7 @@ private:
     int m_onUpdatesDisabledUnfocusedWindowId;
     LipstickRecorderManager *m_recorder;
     LipstickKeymap *m_keymap;
+    bool m_fakeRepaintTriggered;
 };
 
 #endif // LIPSTICKCOMPOSITOR_H

--- a/tests/stubs/lipstickcompositor_stub.h
+++ b/tests/stubs/lipstickcompositor_stub.h
@@ -60,6 +60,7 @@ class LipstickCompositorStub : public StubBase {
   virtual void readContent();
   virtual void initialize();
   virtual bool completed();
+  virtual void timerEvent(QTimerEvent *e);
 }; 
 
 // 2. IMPLEMENT STUB
@@ -251,6 +252,13 @@ void LipstickCompositorStub::initialize() {
 bool LipstickCompositorStub::completed() {
     stubMethodEntered("completed");
     return true;
+}
+
+void LipstickCompositorStub::timerEvent(QTimerEvent *e)
+{
+    QList<ParameterBase*> params;
+    params.append( new Parameter<QTimerEvent *>(e));
+    stubMethodEntered("timerEvent", params);
 }
 
 #if QT_VERSION >= QT_VERSION_CHECK(5, 2, 0)
@@ -513,6 +521,11 @@ void LipstickCompositor::initialize() {
 
 bool LipstickCompositor::completed() {
     return gLipstickCompositorStub->completed();
+}
+
+void LipstickCompositor::timerEvent(QTimerEvent *e)
+{
+    gLipstickCompositorStub->timerEvent(e);
 }
 
 #if QT_VERSION < QT_VERSION_CHECK(5, 2, 0)


### PR DESCRIPTION
…R#1004

When the display is off we don't repaint so we don't normally send frame
callbacks, which means a client calling eglSwapBuffers() will wait until
the screen comes back on. To prevent that we send the frame callbacks when
a client commits a surface, after a 100ms delay to prevent the clients going
full speed when they should not be drawing.


This partially reverts https://github.com/nemomobile/lipstick/commit/ea65e244ee39959faa825e46b7d441a5202d20b7, but only restores one of the two commits, which doesn't cause the issues that made the revert necessary.