### PR TITLE
[lipstick] Use MCE to turn display on for notifications. Contributes to MER#1076

### DIFF
--- a/tests/ut_notificationpreviewpresenter/ut_notificationpreviewpresenter.cpp
+++ b/tests/ut_notificationpreviewpresenter/ut_notificationpreviewpresenter.cpp
@@ -109,6 +109,7 @@ const char *NotificationManager::HINT_REMOTE_ACTION_PREFIX = "x-nemo-remote-acti
 const char *NotificationManager::HINT_REMOTE_ACTION_ICON_PREFIX = "x-nemo-remote-action-icon-";
 const char *NotificationManager::HINT_HIDDEN = "x-nemo-hidden";
 const char *NotificationManager::HINT_USER_REMOVABLE = "x-nemo-user-removable";
+const char *NotificationManager::HINT_DISPLAY_ON = "x-nemo-display-on";
 const char *NotificationManager::HINT_ORIGIN = "x-nemo-origin";
 const char *NotificationManager::HINT_OWNER = "x-nemo-owner";
 


### PR DESCRIPTION
Use the notification-specific function for turning on the display.