### PR TITLE
[lipstick] Prevent lipstick from killing random apps. Fixes JB#29648

### DIFF
--- a/src/compositor/lipstickcompositorwindow.cpp
+++ b/src/compositor/lipstickcompositorwindow.cpp
@@ -382,14 +382,19 @@ void LipstickCompositorWindow::handleTouchCancel()
 
 void LipstickCompositorWindow::terminateProcess(int killTimeout)
 {
-    kill(processId(), SIGTERM);
-
-    QTimer::singleShot(killTimeout, this, SLOT(killProcess()));
+    pid_t pid = processId();
+    if (pid > 0) {
+        kill(pid, SIGTERM);
+        QTimer::singleShot(killTimeout, this, SLOT(killProcess()));
+    }
 }
 
 void LipstickCompositorWindow::killProcess()
 {
-    kill(processId(), SIGKILL);
+    pid_t pid = processId();
+    if (pid > 0) {
+        kill(pid, SIGKILL);
+    }
 }
 
 void LipstickCompositorWindow::connectSurfaceSignals()


### PR DESCRIPTION
Check that pid is positive before trying to kill.

With some bad luck, lcw can belong to an application that does no
longer have a surface, or does not have a client, or the surface
is in the process of being destroyed. In those cases, it is possible
that trying to terminate the process would call kill with
pid 0 or -1.