### PR TITLE
[lipstick] Remove feedback from Twitter messages notifications. Contributes to MER#1035

### DIFF
--- a/src/androidnotificationpriorities
+++ b/src/androidnotificationpriorities
@@ -2,7 +2,7 @@ Skype;chat
 WhatsApp;chat
 Facebook Messenger;chat
 WeChat;chat
-Twitter messages;chat
+Twitter messages
 Telegram;chat
 Snapchat;chat
 vk.com;chat


### PR DESCRIPTION
Notifications from 'Twitter messages' should not cause sound or LED feedback events.