### PR TITLE
[lipstick] Fix reporting of deleted model rows. Contributes to MER#1099

### DIFF
--- a/src/utilities/qobjectlistmodel.cpp
+++ b/src/utilities/qobjectlistmodel.cpp
@@ -158,7 +158,7 @@ void QObjectListModel::removeItems(const QList<QObject *> &items)
                 --first;
             }
 
-            beginRemoveRows(QModelIndex(), first, last);
+            beginRemoveRows(QModelIndex(), removals.at(first).first, removals.at(last).first);
             while (last >= first) {
                 const QPair<int, QObject *> &removal(removals.at(last));
                 --last;


### PR DESCRIPTION
In the case of batch deletion, the rows reported as removed from the model are often not the ones actually removed.