### PR TITLE
[lipstick] Disable mouse event synthesis. Fixes JB#24350

### DIFF
--- a/src/compositor/lipstickcompositorwindow.cpp
+++ b/src/compositor/lipstickcompositorwindow.cpp
@@ -38,6 +38,9 @@ LipstickCompositorWindow::LipstickCompositorWindow(int windowId, const QString &
     setFlags(QQuickItem::ItemIsFocusScope | flags());
     refreshMouseRegion();
 
+    // XXX: We don't want synthesized mouse events
+    setAcceptedMouseButtons(acceptedMouseButtons() & ~Qt::LeftButton);
+
     // Handle ungrab situations
     connect(this, SIGNAL(visibleChanged()), SLOT(handleTouchCancel()));
     connect(this, SIGNAL(enabledChanged()), SLOT(handleTouchCancel()));
@@ -335,7 +338,8 @@ void LipstickCompositorWindow::handleTouchEvent(QTouchEvent *event)
         return;
     }
 
-    if (event->touchPointStates() & Qt::TouchPointPressed) {
+    // Only check the input region on TouchBegin
+    if (event->type() == QEvent::TouchBegin) {
         foreach (const QTouchEvent::TouchPoint &p, points) {
             if ((m_mouseRegionValid && !m_mouseRegion.contains(p.pos().toPoint())) ||
                 !m_surface->inputRegionContains(p.pos().toPoint())) {


### PR DESCRIPTION
When a touch event is ignored, it causes QtQuick to try a synthesized
mouse event. Disable event synthesis (checks internally for
Qt::LeftButton) to prevent entering zone of undefined behavior, as
Qt will keep on sending further touch events to the item, and we are
not ready to handle them.

This could be an issue in Qt -- touch events probably should not be
delivered to an item that accepted a synthesized mouse press.