### PR TITLE
[lipstick] Default notification priority when unspecified. Contributes to MER#1118

### DIFF
--- a/doc/src/notifications.dox
+++ b/doc/src/notifications.dox
@@ -82,7 +82,7 @@
  *   - The service supports the following Nemo specific hints:
  *       - \c x-nemo-icon: icon ID or path for the notification. This may be a file:// URL, else if the string begins with a / it's interpreted to be an absolute path. Otherwise it's interpreted to be an icon ID, in which case the icon with the given ID is fetched from the theme. This hint is deprecated in favor of the standard \c image-path hint.
  *       - \c x-nemo-item-count: the number of items represented by this notification. For example, a single notification can represent four missed calls by setting the count to 4.
- *       - \c x-nemo-priority: the priority of the notification as an integer. Priorities can be used by UI implementations to present notifications in a specific order, for example.
+ *       - \c x-nemo-priority: the priority of the notification as an integer. Priorities can be used by UI implementations to present notifications in a specific order, for example. If not specified, the priority level will be allocated 50.
  *       - \c x-nemo-timestamp: the timestamp for the notification. Should be set to the time when the event the notification is related to has occurred, not when the notification itself was sent.
  *       - \c x-nemo-preview-icon: icon ID or path to use in the preview banner for the notification, if any.
  *       - \c x-nemo-preview-body: body text to be shown in the preview banner for the notification, if any.

--- a/src/notifications/notificationmanager.cpp
+++ b/src/notifications/notificationmanager.cpp
@@ -83,6 +83,8 @@ const char *NotificationManager::HINT_MAX_CONTENT_LINES = "x-nemo-max-content-li
 
 namespace {
 
+const int DefaultNotificationPriority = 50;
+
 QPair<QString, QString> processProperties(uint pid)
 {
     // Cache resolution of process name to properties:
@@ -300,6 +302,11 @@ uint NotificationManager::Notify(const QString &appName, uint replacesId, const 
             }
             if (notification->appIcon().isEmpty() && !pidProperties.second.isEmpty()) {
                 notification->setAppIcon(pidProperties.second);
+            }
+
+            // Unspecified priority should result in medium priority to permit low priorities
+            if (!hints_.contains(HINT_PRIORITY)) {
+                hints_.insert(HINT_PRIORITY, DefaultNotificationPriority);
             }
         }
 


### PR DESCRIPTION
Default priority should be medium to allow notifications to specify a low relative priority if desired.