### PR TITLE
[lipstick] Export screen size as dconf keys. Contributes to MER#1124

### DIFF
--- a/src/homeapplication.cpp
+++ b/src/homeapplication.cpp
@@ -86,6 +86,9 @@ HomeApplication::HomeApplication(int &argc, char **argv, const QString &qmlPath)
     NotificationManager::instance();
     new NotificationPreviewPresenter(this);
 
+    // Export screen size / geometry as dconf keys
+    LipstickSettings::instance()->exportScreenSize();
+
     // Create screen lock logic - not parented to "this" since destruction happens too late in that case
     screenLock = new ScreenLock;
     LipstickSettings::instance()->setScreenLock(screenLock);

--- a/src/lipsticksettings.cpp
+++ b/src/lipsticksettings.cpp
@@ -17,6 +17,7 @@
 
 #include <QGuiApplication>
 #include <QScreen>
+#include <MGConfItem>
 #include "screenlock/screenlock.h"
 #include "homeapplication.h"
 #include "lipsticksettings.h"
@@ -75,6 +76,21 @@ void LipstickSettings::lockScreen(bool immediate)
 QSize LipstickSettings::screenSize()
 {
     return QGuiApplication::primaryScreen()->size();
+}
+
+void LipstickSettings::exportScreenSize()
+{
+    const int defaultValue = 0;
+    MGConfItem widthConf("/lipstick/screen/primary/width");
+    if (widthConf.value(defaultValue) != QGuiApplication::primaryScreen()->size().width()) {
+        widthConf.set(QGuiApplication::primaryScreen()->size().width());
+        widthConf.sync();
+    }
+    MGConfItem heightConf("/lipstick/screen/primary/height");
+    if (heightConf.value(defaultValue) != QGuiApplication::primaryScreen()->size().height()) {
+        heightConf.set(QGuiApplication::primaryScreen()->size().height());
+        heightConf.sync();
+    }
 }
 
 QString LipstickSettings::blankingPolicy()

--- a/src/lipsticksettings.h
+++ b/src/lipsticksettings.h
@@ -43,6 +43,7 @@ public:
     bool lowPowerMode() const;
 
     QSize screenSize();
+    void exportScreenSize();
 
     QString blankingPolicy();
 


### PR DESCRIPTION
This commit adds code to export the screen size width/height values
to dconf so that non-gui processes can access those values (e.g., to
determine optimal image sizes to sync).

Contributes to MER#1124