### PR TITLE
Fix notification crash

### DIFF
--- a/src/notifications/notificationmanager.cpp
+++ b/src/notifications/notificationmanager.cpp
@@ -928,7 +928,11 @@ void NotificationManager::removeNotificationIfUserRemovable(uint id)
         }
     }
 
-    LipstickNotification *notification = notifications[id];
+    LipstickNotification *notification = notifications.value(id);
+    if (!notification) {
+        return;
+    }
+
     QVariant userRemovable = notification->hints().value(HINT_USER_REMOVABLE);
     if (!userRemovable.isValid() || userRemovable.toBool()) {
         // The notification should be removed if user removability is not defined (defaults to true) or is set to true


### PR DESCRIPTION
Alternative fix for
https://github.com/nemomobile/lipstick/pull/360

Worst offender was notifications[id] which as side-effect created a default constructed value on QHash.

Also noticed D-Bus handler missing a bit protection on input.

If good to go, I'll pick these to 1.1.9 too.