### PR TITLE
[battery] Notify about charging completion only once. Fixes MER#1171

### DIFF
--- a/src/notifications/batterynotifier.h
+++ b/src/notifications/batterynotifier.h
@@ -160,6 +160,11 @@ private:
     };
     State lastState;
     Mode mode;
+    enum ChargingCompletion {
+        NeedsCharging,
+        FullyCharged
+    };
+    ChargingCompletion chargingCompletion;
 
     /*! Notification is postponed by means of this timer to skip
      *  frequent state changes during energy management state


### PR DESCRIPTION
Do not notify on charging completion during maintenance charging cycles

Signed-off-by: Denis Zalevskiy <denis.zalevskiy@jolla.com>