### PR TITLE
[lipstick] Identify Android notifications by package name. Contributes to MER#1185

### DIFF
--- a/src/androidnotificationpriorities
+++ b/src/androidnotificationpriorities
@@ -1,10 +1,29 @@
 Skype;chat,chat_exists
+package:com.skype.raider;chat,chat_exists
+
 WhatsApp;chat,chat_exists
+package:com.whatsapp;chat,chat_exists
+
 Facebook Messenger;chat,chat_exists
+package:com.facebook.orca;chat,chat_exists
+
 WeChat;chat,chat_exists
+package:com.tencent.mm;chat,chat_exists
+
 Twitter messages
+package:com.twitter.android
+
 Telegram;chat,chat_exists
+package:org.telegram.messenger;chat,chat_exists
+
 Snapchat;chat,chat_exists
+package:com.snapchat.android;chat,chat_exists
+
 vk.com;chat,chat_exists
+package:com.vkontakte.android;chat,chat_exists
+
 kik;chat,chat_exists
+package:kik.android;chat,chat_exists
+
 viber;chat,chat_exists
+package:com.viber.voip;chat,chat_exists

--- a/src/notifications/androidprioritystore.h
+++ b/src/notifications/androidprioritystore.h
@@ -41,6 +41,13 @@ public:
      */
     PriorityDetails appDetails(const QString &appName) const;
 
+    /*!
+     * Returns the priority information defined for the given Android package name.
+     *
+     * \param packageName The name of the Android package to return priority information for.
+     */
+    PriorityDetails packageDetails(const QString &packageName) const;
+
 private:
     QHash<QString, QString> priorityDefinitions;
 };

--- a/src/notifications/notificationmanager.cpp
+++ b/src/notifications/notificationmanager.cpp
@@ -78,6 +78,7 @@ const char *NotificationManager::HINT_HIDDEN = "x-nemo-hidden";
 const char *NotificationManager::HINT_DISPLAY_ON = "x-nemo-display-on";
 const char *NotificationManager::HINT_LED_DISABLED_WITHOUT_BODY_AND_SUMMARY = "x-nemo-led-disabled-without-body-and-summary";
 const char *NotificationManager::HINT_ORIGIN = "x-nemo-origin";
+const char *NotificationManager::HINT_ORIGIN_PACKAGE = "x-nemo-origin-package";
 const char *NotificationManager::HINT_OWNER = "x-nemo-owner";
 const char *NotificationManager::HINT_MAX_CONTENT_LINES = "x-nemo-max-content-lines";
 const char *NotificationManager::HINT_RESTORED = "x-nemo-restored";
@@ -292,7 +293,13 @@ uint NotificationManager::Notify(const QString &appName, uint replacesId, const 
             }
 
             // See if this notification has elevated priority and feedback
-            AndroidPriorityStore::PriorityDetails priority(androidPriorityStore->appDetails(appName));
+            AndroidPriorityStore::PriorityDetails priority;
+            const QString packageName(hints_.value(HINT_ORIGIN_PACKAGE).toString());
+            if (!packageName.isEmpty()) {
+                priority = androidPriorityStore->packageDetails(packageName);
+            } else {
+                priority = androidPriorityStore->appDetails(appName);
+            }
             hints_.insert(HINT_PRIORITY, priority.first);
             if (!priority.second.isEmpty()) {
                 hints_.insert(HINT_FEEDBACK, priority.second);

--- a/src/notifications/notificationmanager.h
+++ b/src/notifications/notificationmanager.h
@@ -105,6 +105,9 @@ public:
     //! Nemo hint: Indicates the origin of the notification
     static const char *HINT_ORIGIN;
 
+    //! Nemo hint: Indicates the Android package name from which this notification originates
+    static const char *HINT_ORIGIN_PACKAGE;
+
     //! Nemo hint: Indicates the identifer of the owner for notification
     static const char *HINT_OWNER;
 

--- a/tests/stubs/androidprioritystore_stub.h
+++ b/tests/stubs/androidprioritystore_stub.h
@@ -24,6 +24,7 @@ class AndroidPriorityStoreStub : public StubBase {
   public:
   virtual void AndroidPriorityStoreStubConstructor(const QString &path, QObject *parent);
   virtual AndroidPriorityStore::PriorityDetails appDetails(const QString &appName) const;
+  virtual AndroidPriorityStore::PriorityDetails packageDetails(const QString &packageName) const;
 };
 
 // 2. IMPLEMENT STUB
@@ -39,6 +40,13 @@ AndroidPriorityStore::PriorityDetails AndroidPriorityStoreStub::appDetails(const
   return stubReturnValue<AndroidPriorityStore::PriorityDetails >("appDetails");
 }
 
+AndroidPriorityStore::PriorityDetails AndroidPriorityStoreStub::packageDetails(const QString &packageName) const {
+  QList<ParameterBase*> params;
+  params.append( new Parameter<const QString & >(packageName));
+  stubMethodEntered("packageDetails",params);
+  return stubReturnValue<AndroidPriorityStore::PriorityDetails >("packageDetails");
+}
+
 // 3. CREATE A STUB INSTANCE
 AndroidPriorityStoreStub gDefaultAndroidPriorityStoreStub;
 AndroidPriorityStoreStub* gAndroidPriorityStoreStub = &gDefaultAndroidPriorityStoreStub;
@@ -51,6 +59,10 @@ AndroidPriorityStore::AndroidPriorityStore(const QString &path, QObject *parent)
 
 AndroidPriorityStore::PriorityDetails AndroidPriorityStore::appDetails(const QString &appName) const {
   return gAndroidPriorityStoreStub->appDetails(appName);
+}
+
+AndroidPriorityStore::PriorityDetails AndroidPriorityStore::packageDetails(const QString &appName) const {
+  return gAndroidPriorityStoreStub->packageDetails(appName);
 }
 
 #endif


### PR DESCRIPTION
The package name is not subject to localization, so prefer to identify Android notifications by that value rather than their human-readable name value.