### PR TITLE
[lipstick] Do not trigger preview when notification is updated. Contributes to MER#1187

### DIFF
--- a/src/notifications/notificationmanager.cpp
+++ b/src/notifications/notificationmanager.cpp
@@ -565,6 +565,9 @@ void NotificationManager::publish(const LipstickNotification *notification, uint
 
     NOTIFICATIONS_DEBUG("PUBLISH:" << notification->appName() << notification->appIcon() << notification->summary() << notification->body() << notification->actions() << notification->hints() << notification->expireTimeout() << "->" << id);
     emit notificationModified(id);
+    if (replacesId == 0) {
+        emit notificationAdded(id);
+    }
 }
 
 void NotificationManager::restoreNotifications()

--- a/src/notifications/notificationmanager.h
+++ b/src/notifications/notificationmanager.h
@@ -239,6 +239,13 @@ signals:
     void ActionInvoked(uint id, const QString &actionKey);
 
     /*!
+     * Emitted when a notification is added.
+     *
+     * \param id the ID of the added notification
+     */
+    void notificationAdded(uint id);
+
+    /*!
      * Emitted when a notification is modified (added or updated).
      *
      * \param id the ID of the modified notification

--- a/src/notifications/notificationpreviewpresenter.cpp
+++ b/src/notifications/notificationpreviewpresenter.cpp
@@ -60,7 +60,7 @@ NotificationPreviewPresenter::NotificationPreviewPresenter(QObject *parent) :
     locks(new MeeGo::QmLocks(this)),
     displayState(new MeeGo::QmDisplayState(this))
 {
-    connect(NotificationManager::instance(), SIGNAL(notificationModified(uint)), this, SLOT(updateNotification(uint)));
+    connect(NotificationManager::instance(), SIGNAL(notificationAdded(uint)), this, SLOT(updateNotification(uint)));
     connect(NotificationManager::instance(), SIGNAL(notificationRemoved(uint)), this, SLOT(removeNotification(uint)));
     connect(this, SIGNAL(notificationPresented(uint)), notificationFeedbackPlayer, SLOT(addNotification(uint)));
 

--- a/tests/ut_notificationpreviewpresenter/ut_notificationpreviewpresenter.cpp
+++ b/tests/ut_notificationpreviewpresenter/ut_notificationpreviewpresenter.cpp
@@ -220,7 +220,7 @@ void Ut_NotificationPreviewPresenter::cleanup()
 void Ut_NotificationPreviewPresenter::testSignalConnections()
 {
     NotificationPreviewPresenter presenter;
-    QCOMPARE(disconnect(NotificationManager::instance(), SIGNAL(notificationModified(uint)), &presenter, SLOT(updateNotification(uint))), true);
+    QCOMPARE(disconnect(NotificationManager::instance(), SIGNAL(notificationAdded(uint)), &presenter, SLOT(updateNotification(uint))), true);
     QCOMPARE(disconnect(NotificationManager::instance(), SIGNAL(notificationRemoved(uint)), &presenter, SLOT(removeNotification(uint))), true);
     QCOMPARE(disconnect(&presenter, SIGNAL(notificationPresented(uint)), presenter.notificationFeedbackPlayer, SLOT(addNotification(uint))), true);
 }


### PR DESCRIPTION
Updates to existing notifications are supposed to occur without the user being made aware of any changes.  Previews should be triggered only for initial publication of notifications.