### PR TITLE
[lipstick] Cache notification values to optimize comparisons. Contributes to MER#1221

### DIFF
--- a/src/notifications/lipsticknotification.h
+++ b/src/notifications/lipsticknotification.h
@@ -170,6 +170,8 @@ public:
     bool restored() const;
 
     //! \internal
+    quint64 internalTimestamp() const;
+
     /*!
      * Creates a copy of an existing representation of a notification.
      * This constructor should only be used for populating the notification
@@ -260,6 +262,10 @@ private:
 
     //! Expiration timeout for the notification
     int expireTimeout_;
+
+    // Cached values for speeding up comparisons:
+    int priority_;
+    quint64 timestamp_;
 };
 
 Q_DECLARE_METATYPE(LipstickNotification)

--- a/src/notifications/notificationlistmodel.cpp
+++ b/src/notifications/notificationlistmodel.cpp
@@ -20,7 +20,7 @@ namespace {
 
 int compare(const LipstickNotification &lhs, const LipstickNotification &rhs)
 {
-    const QDateTime lhsTimestamp(lhs.timestamp()), rhsTimestamp(rhs.timestamp());
+    const quint64 lhsTimestamp(lhs.internalTimestamp()), rhsTimestamp(rhs.internalTimestamp());
     if (lhsTimestamp < rhsTimestamp) {
         return -1;
     }


### PR DESCRIPTION
Store notification priority and timestamp values in optimal form for comparison, as comparison time dominates the cost of populating and maintaining notification models.