### PR TITLE
[lipstick] devicelock triggers randomly. Fixes JB#31885

### DIFF
--- a/src/devicelock/devicelock.cpp
+++ b/src/devicelock/devicelock.cpp
@@ -171,7 +171,7 @@ void DeviceLock::setupLockTimer()
             // Locking disabled or device active: stop the timer
             lockTimer->stop();
             monoTime.tv_sec = 0;
-        } else if (!isCallActive && !monoTime.tv_sec) {
+        } else if (!isCallActive && !monoTime.tv_sec && m_activity == MeeGo::QmActivity::Inactive) {
             // Locking in N minutes enabled and device inactive: start the timer
             lockTimer->start(lockingDelay * 60 * 1000);
             tv_get_monotime(&monoTime);


### PR DESCRIPTION
In a very long time ago activity signal only came after display state signal. But MCE has changed a while back to be async, and its possible that activity is true even when display is still off (as display can take ~300ms to wake up on some devices). This patch makes sure that lockTimer is only started when device is inactive (and not starting it when device is waking up).