### PR TITLE
[lipstick] Fix device unlock sequence. Fixes JB#31285

### DIFF
--- a/src/devicelock/devicelock.cpp
+++ b/src/devicelock/devicelock.cpp
@@ -237,6 +237,7 @@ void DeviceLock::setState(int state)
         if (state == Locked || isPrivileged()) {
             deviceLockState = (LockState)state;
             emit stateChanged(state);
+            emit _notifyStateChanged();
 
             setupLockTimer();
         } else {

--- a/src/devicelock/devicelock.h
+++ b/src/devicelock/devicelock.h
@@ -31,7 +31,7 @@ class DeviceLock : public QObject, protected QDBusContext
 {
     Q_OBJECT
     Q_ENUMS(LockState)
-    Q_PROPERTY(int state READ state WRITE setState NOTIFY stateChanged)
+    Q_PROPERTY(int state READ state WRITE setState NOTIFY _notifyStateChanged)
     Q_PROPERTY(bool blankingPause READ blankingPause NOTIFY blankingPauseChanged)
     Q_PROPERTY(bool blankingInhibit READ blankingInhibit NOTIFY blankingInhibitChanged)
 
@@ -56,6 +56,8 @@ public:
 
 signals:
     void stateChanged(int state);
+    // Signal the property change independently of the dbus signal to enfore the order of emission.
+    void _notifyStateChanged();
     void blankingPauseChanged();
     void blankingInhibitChanged();
 


### PR DESCRIPTION
Emit the device lock state change over dbus before updating the UI
so that MCE is in the correct state before there is any attempt to
unlock the screen.